### PR TITLE
ci: standardize frontend build on go generate

### DIFF
--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -31,8 +31,7 @@ jobs:
         run: bun install
 
       - name: Build frontend
-        working-directory: web-ui
-        run: bun run build
+        run: go generate ./internal/web/...
 
       - name: Download dependencies
         run: go mod download

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,10 +32,9 @@ go mod verify      # Verify deps
 ### Frontend (web-ui) — requires `bun`
 
 ```bash
-(cd web-ui && bun install)        # Install JS dependencies
-bun --cwd web-ui run dev          # Dev server with HMR (proxies /api, /ws to :8321)
-bun --cwd web-ui run build        # Build into internal/web/static/ (embedded into binary)
-go generate ./internal/web/...    # Same as above, via go generate
+(cd web-ui && bun install)        # Install JS dependencies (one-time setup)
+go generate ./internal/web/...    # Build frontend into internal/web/static/
+bun run --cwd web-ui dev          # Dev server with HMR (proxies /api, /ws to :8321)
 ```
 
 ## Architecture

--- a/internal/web/embed.go
+++ b/internal/web/embed.go
@@ -2,7 +2,7 @@ package web
 
 import "embed"
 
-//go:generate bun --cwd ../../web-ui run build
+//go:generate bun run --cwd ../../web-ui build
 
 //go:embed static/*
 var staticFS embed.FS


### PR DESCRIPTION
## Summary

- Fix `//go:generate` directive in `embed.go` — move `--cwd` flag from `bun` to `bun run` subcommand to work with bun 1.3.x
- Replace direct `bun run build` in CI workflow with `go generate ./internal/web/...` so the build command is defined in one place
- Simplify AGENTS.md frontend instructions to use `go generate` as the single build approach, removing duplicate `bun run build` entry