### PR TITLE
ui(web): clear lines on filter change and small adjustments

### DIFF
--- a/internal/web/message.go
+++ b/internal/web/message.go
@@ -46,6 +46,10 @@ func newErrorMsg(message string) serverMsg {
 	return serverMsg{Type: "error", Data: errorPayload{Message: message}}
 }
 
+func newClearLinesMsg() serverMsg {
+	return serverMsg{Type: "clearLines"}
+}
+
 // --- Client -> Server messages ---
 
 type connectCmd struct {

--- a/internal/web/session.go
+++ b/internal/web/session.go
@@ -106,6 +106,13 @@ func (s *Session) Drain() []model.LogLine {
 	return lines
 }
 
+// ClearBuffer empties the ring buffer of previously collected lines.
+func (s *Session) ClearBuffer() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.buffer.Clear()
+}
+
 // UpdateFilter hot-swaps the filter on the running reader.
 func (s *Session) UpdateFilter(filter model.Filter) {
 	s.mu.Lock()

--- a/internal/web/ws.go
+++ b/internal/web/ws.go
@@ -98,6 +98,8 @@ func wsReadLoop(ctx context.Context, conn *websocket.Conn, session *Session, dem
 		case "updateFilter":
 			cmd := payload.(updateFilterCmd)
 			session.UpdateFilter(cmd.Filter)
+			session.ClearBuffer()
+			writeJSON(ctx, conn, newClearLinesMsg())
 
 		case "listDevices":
 			if demo {

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -30,6 +30,7 @@ export default function App() {
   const wsRef = useRef<LogcatWebSocket | null>(null);
   const logContainerRef = useRef<HTMLDivElement>(null);
   const autoScrollRef = useRef(true);
+  const filterRef = useRef<Filter>({});
 
   useEffect(() => {
     autoScrollRef.current = autoScroll;
@@ -69,6 +70,9 @@ export default function App() {
       case "devices":
         setDevices(msg.data);
         break;
+      case "clearLines":
+        setLines([]);
+        break;
       case "error":
         setError(msg.message);
         break;
@@ -95,7 +99,7 @@ export default function App() {
   const connectToDevice = useCallback((deviceId: string) => {
     setLines([]);
     setError(null);
-    wsRef.current?.send({ type: "connect", deviceId });
+    wsRef.current?.send({ type: "connect", deviceId, filter: filterRef.current });
   }, []);
 
   const disconnect = useCallback(() => {
@@ -109,6 +113,7 @@ export default function App() {
   }, []);
 
   const handleFilterChange = useCallback((filter: Filter) => {
+    filterRef.current = filter;
     wsRef.current?.send({ type: "updateFilter", filter });
   }, []);
 
@@ -192,7 +197,7 @@ export default function App() {
           flex={1}
           overflow="auto"
           fontFamily="monospace"
-          py={0.5}
+          pb={0.5}
         >
           {/* Sticky column header */}
           <Box

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -255,7 +255,6 @@ export default function App() {
       )}
 
       <StatusBar
-        lineCount={lines.length}
         activeDevice={activeDevice}
         connected={connected}
         autoScroll={autoScroll}

--- a/web-ui/src/components/DeviceBar.tsx
+++ b/web-ui/src/components/DeviceBar.tsx
@@ -1,5 +1,3 @@
-import AppBar from "@mui/material/AppBar";
-import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import ToggleButton from "@mui/material/ToggleButton";
@@ -39,58 +37,56 @@ export default function DeviceBar({
   };
 
   return (
-    <AppBar position="static" color="default" elevation={1}>
-      <Toolbar variant="dense">
-        <Typography variant="subtitle2" fontFamily="monospace" noWrap sx={{ mr: 2 }}>
-          lazylogcat
-        </Typography>
+    <Box display="flex" alignItems="center" gap={1} px={1} py={0.5} borderBottom={1} borderColor="divider">
+      <Typography variant="subtitle2" fontFamily="monospace" noWrap sx={{ mr: 1 }}>
+        lazylogcat
+      </Typography>
 
-        <Chip
-          size="small"
-          label={wsConnected ? "live" : "offline"}
-          color={wsConnected ? "success" : "error"}
-          variant="outlined"
-        />
+      <Chip
+        size="small"
+        label={wsConnected ? "live" : "offline"}
+        color={wsConnected ? "success" : "error"}
+        variant="outlined"
+      />
 
-        <Divider orientation="vertical" flexItem sx={{ mx: 1 }} />
+      <Divider orientation="vertical" flexItem />
 
-        {devices.length > 0 ? (
-          <Box display="flex" alignItems="center" gap={0.5} flex={1} overflow="hidden">
-            <ToggleButtonGroup
-              value={activeDevice ?? ""}
-              exclusive
-              onChange={handleChange}
-              size="small"
-            >
-              {devices.map((device) => (
-                <ToggleButton key={device.id} value={device.id}>
-                  {device.name || device.id}
-                </ToggleButton>
-              ))}
-            </ToggleButtonGroup>
+      {devices.length > 0 ? (
+        <Box display="flex" alignItems="center" gap={0.5} flex={1} overflow="hidden">
+          <ToggleButtonGroup
+            value={activeDevice ?? ""}
+            exclusive
+            onChange={handleChange}
+            size="small"
+          >
+            {devices.map((device) => (
+              <ToggleButton key={device.id} value={device.id}>
+                {device.name || device.id}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
 
-            {activeDevice && connected && (
-              <IconButton size="small" onClick={onDisconnect} title="Disconnect">
-                <CloseIcon fontSize="small" />
-              </IconButton>
-            )}
-          </Box>
-        ) : (
-          <Box flex={1}>
-            <Typography variant="body2" color="text.disabled">
-              no devices
-            </Typography>
-          </Box>
-        )}
+          {activeDevice && connected && (
+            <IconButton size="small" onClick={onDisconnect} title="Disconnect">
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          )}
+        </Box>
+      ) : (
+        <Box flex={1}>
+          <Typography variant="body2" color="text.disabled">
+            no devices
+          </Typography>
+        </Box>
+      )}
 
-        <Divider orientation="vertical" flexItem sx={{ mx: 1 }} />
+      <Divider orientation="vertical" flexItem />
 
-        <ThemeSwitcher />
+      <ThemeSwitcher />
 
-        <IconButton onClick={onRefresh} title="Refresh device list" size="small">
-          <RefreshIcon fontSize="small" />
-        </IconButton>
-      </Toolbar>
-    </AppBar>
+      <IconButton onClick={onRefresh} title="Refresh device list" size="small">
+        <RefreshIcon fontSize="small" />
+      </IconButton>
+    </Box>
   );
 }

--- a/web-ui/src/components/FilterBar.tsx
+++ b/web-ui/src/components/FilterBar.tsx
@@ -71,7 +71,7 @@ export default function FilterBar({ onFilterChange, disabled }: FilterBarProps) 
         size="small"
       >
         {LEVELS.map((l) => (
-          <ToggleButton key={l} value={l}>
+          <ToggleButton key={l} value={l} sx={{ width: 32, minWidth: 0, px: 0 }}>
             {l}
           </ToggleButton>
         ))}

--- a/web-ui/src/components/StatusBar.tsx
+++ b/web-ui/src/components/StatusBar.tsx
@@ -4,7 +4,6 @@ import Button from "@mui/material/Button";
 import Switch from "@mui/material/Switch";
 
 interface StatusBarProps {
-  lineCount: number;
   activeDevice: string | null;
   connected: boolean;
   autoScroll: boolean;
@@ -13,7 +12,6 @@ interface StatusBarProps {
 }
 
 export default function StatusBar({
-  lineCount,
   activeDevice,
   connected,
   autoScroll,
@@ -31,13 +29,6 @@ export default function StatusBar({
       borderColor="divider"
     >
       <Box display="flex" alignItems="center" gap={1}>
-        <Typography variant="body2" color="text.secondary">
-          <Typography variant="body2" component="span" color="primary">
-            {lineCount.toLocaleString()}
-          </Typography>
-          {" lines"}
-        </Typography>
-
         {activeDevice && connected && (
           <Typography variant="body2" color="text.disabled">
             {activeDevice}

--- a/web-ui/src/lib/types.ts
+++ b/web-ui/src/lib/types.ts
@@ -61,12 +61,17 @@ export interface ErrorMessage {
   message: string;
 }
 
+export interface ClearLinesMessage {
+  type: "clearLines";
+}
+
 export type ServerMessage =
   | LinesMessage
   | ConnectedMessage
   | DisconnectedMessage
   | DevicesMessage
-  | ErrorMessage;
+  | ErrorMessage
+  | ClearLinesMessage;
 
 // Client -> Server messages
 


### PR DESCRIPTION
## Summary

- **Clear lines on filter change**: when the user updates a filter, the server now clears the session ring buffer and sends a `clearLines` message so the frontend resets its log list — prevents stale lines from a previous filter from lingering.
- **Small UI adjustments**: removed the line-count display from StatusBar, replaced the heavy `AppBar`/`Toolbar` wrapper in DeviceBar with a lightweight `Box` layout, and tightened toggle-button sizing in FilterBar.

### Backend changes (`internal/web`)
- Added `Session.ClearBuffer()` method to empty the ring buffer
- Added `newClearLinesMsg()` server message constructor (`type: "clearLines"`)
- Wired both into the `updateFilter` WebSocket handler

### Frontend changes (`web-ui`)
- Handle `clearLines` server message in `App.tsx` to reset displayed lines
- Track current filter via `filterRef` and send it on device connect
- Simplified DeviceBar layout (AppBar → Box)
- Removed line-count prop from StatusBar