### PR TITLE
feat(cli): help examples and adb PATH remediation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,9 @@ var rootCmd = &cobra.Command{
 	Use:          "lazylogcat",
 	Short:        "Interactive Android logcat viewer",
 	Long:         `lazylogcat is an interactive TUI application for viewing Android device logs.`,
+	Example: `  lazylogcat
+  lazylogcat --pkg com.example.app --tag MainActivity
+  lazylogcat --text error --debug`,
 	SilenceUsage: true,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return app.SetupLogging(debugFlag)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -30,6 +30,7 @@ func getVersion() string {
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",
+	Example: `  lazylogcat version`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(getVersion())
 	},

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -21,7 +21,7 @@ var (
 func PreLaunchChecks() error {
 	_, err := exec.LookPath("adb")
 	if err != nil {
-		return ErrAdbNotFound
+		return fmt.Errorf("%w: install Android Debug Bridge (adb) and ensure it is on your PATH", ErrAdbNotFound)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Add Cobra `Example:` blocks on the root command and `version` for copy-pasteable invocations.
- Wrap `ErrAdbNotFound` with a short remediation (install adb, PATH) while preserving `errors.Is`.

## Stack

**1 / 4** — base for the agent-friendly CLI stack. Next: #35 (`cli-stack/devices-config-show-json`).
