### PR TITLE
feat(cli): devices list and config show (JSON)

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/parfenovvs/lazylogcat/internal/app"
+	"github.com/parfenovvs/lazylogcat/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Inspect lazylogcat configuration",
+}
+
+var configShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Print merged configuration as JSON",
+	Long: `Loads and merges configuration from defaults, user config, project config,
+and local override (same rules as the TUI). Warnings about unreadable files go to stderr.`,
+	Example: `  lazylogcat config show`,
+	SilenceUsage: true,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return app.SetupLogging(debugFlag)
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := config.Resolve()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: %v\n", err)
+		}
+		data, err := json.MarshalIndent(c, "", "  ")
+		if err != nil {
+			return fmt.Errorf("encode config: %w", err)
+		}
+		fmt.Println(string(data))
+		return nil
+	},
+	PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+		return app.CloseLog()
+	},
+}
+
+func init() {
+	configCmd.AddCommand(configShowCmd)
+	rootCmd.AddCommand(configCmd)
+}

--- a/cmd/devices.go
+++ b/cmd/devices.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/parfenovvs/lazylogcat/internal/app"
+	"github.com/parfenovvs/lazylogcat/internal/util"
+	"github.com/spf13/cobra"
+)
+
+var devicesOutput string
+
+var devicesCmd = &cobra.Command{
+	Use:   "devices",
+	Short: "List connected Android devices",
+	Long:  `Runs adb devices -l and prints connected devices. Default output is JSON for scripting.`,
+	Example: `  lazylogcat devices
+  lazylogcat devices --output text`,
+	SilenceUsage: true,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return app.SetupLogging(debugFlag)
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := app.PreLaunchChecks(); err != nil {
+			return err
+		}
+		devices, err := util.GetConnectedDevices()
+		if err != nil {
+			return err
+		}
+		switch devicesOutput {
+		case "json":
+			data, err := json.MarshalIndent(devices, "", "  ")
+			if err != nil {
+				return fmt.Errorf("encode devices: %w", err)
+			}
+			fmt.Println(string(data))
+		case "text":
+			for _, d := range devices {
+				fmt.Fprintf(os.Stdout, "%s\t%s\n", d.Id, d.Name)
+			}
+		default:
+			return fmt.Errorf("invalid --output %q (use json or text)", devicesOutput)
+		}
+		return nil
+	},
+	PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+		return app.CloseLog()
+	},
+}
+
+func init() {
+	devicesCmd.Flags().StringVar(&devicesOutput, "output", "json", "Output format: json or text")
+	rootCmd.AddCommand(devicesCmd)
+}


### PR DESCRIPTION
## Summary

- `lazylogcat devices`: list connected devices; default output JSON, `--output text` for plain lines.
- `lazylogcat config show`: print merged configuration as JSON (warnings on stderr if layers fail).

## Stack

**2 / 4** — builds on #34. Next: `cli-stack/logs-dump-and-parse` → #36.
