### PR TITLE
feat(cli): config path overrides and version --json

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/parfenovvs/lazylogcat/internal/app"
-	"github.com/parfenovvs/lazylogcat/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -26,7 +25,7 @@ and local override (same rules as the TUI). Warnings about unreadable files go t
 		return app.SetupLogging(debugFlag)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c, err := config.Resolve()
+		c, err := resolveAppConfig()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: %v\n", err)
 		}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -67,7 +67,7 @@ func runLogsDump(cmd *cobra.Command, args []string) error {
 	if err := validateLogsFormat(logsFormat); err != nil {
 		return err
 	}
-	c, err := config.Resolve()
+	c, err := resolveAppConfig()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: %v\n", err)
 	}
@@ -164,7 +164,7 @@ func runLogsParse(cmd *cobra.Command, args []string) error {
 	if err := validateLogsFormat(logsFormat); err != nil {
 		return err
 	}
-	c, err := config.Resolve()
+	c, err := resolveAppConfig()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: %v\n", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,9 @@ var (
 	pkgFlag  string
 	tagFlag  string
 	textFlag string
+
+	cliProjectConfig string
+	cliLocalConfig   string
 )
 
 var rootCmd = &cobra.Command{
@@ -32,7 +35,7 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
-		c, err := config.Resolve()
+		c, err := resolveAppConfig()
 		if err != nil {
 			slog.Warn("Config resolution had errors", "error", err)
 		}
@@ -57,9 +60,25 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&debugFlag, "debug", false, "Enable debug logging to .lazylogcat.log file")
+	rootCmd.PersistentFlags().StringVar(&cliProjectConfig, "config", "", "Override path for project config (default: .lazylogcat/config.json)")
+	rootCmd.PersistentFlags().StringVar(&cliLocalConfig, "config-local", "", "Override path for local config (default: .lazylogcat/config.local.json)")
 	rootCmd.Flags().StringVar(&pkgFlag, "pkg", "", "Filter by package name (contains match, overrides config)")
 	rootCmd.Flags().StringVar(&tagFlag, "tag", "", "Filter by log tag (contains match, overrides config)")
 	rootCmd.Flags().StringVar(&textFlag, "text", "", "Filter by log text (contains match, overrides config)")
+}
+
+func configOpts() *config.ResolveOptions {
+	if cliProjectConfig == "" && cliLocalConfig == "" {
+		return nil
+	}
+	return &config.ResolveOptions{
+		ProjectConfigPath: cliProjectConfig,
+		LocalConfigPath:   cliLocalConfig,
+	}
+}
+
+func resolveAppConfig() (config.Config, error) {
+	return config.Resolve(configOpts())
 }
 
 func Execute() error {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"runtime/debug"
 
 	"github.com/spf13/cobra"
@@ -27,15 +29,30 @@ func getVersion() string {
 	return "dev"
 }
 
+var versionJSON bool
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",
-	Example: `  lazylogcat version`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Example: `  lazylogcat version
+  lazylogcat version --json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if versionJSON {
+			b, err := json.Marshal(struct {
+				Version string `json:"version"`
+			}{Version: getVersion()})
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(os.Stdout, string(b))
+			return nil
+		}
 		fmt.Println(getVersion())
+		return nil
 	},
 }
 
 func init() {
+	versionCmd.Flags().BoolVar(&versionJSON, "json", false, "Print version as a JSON object")
 	rootCmd.AddCommand(versionCmd)
 }

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -39,7 +39,7 @@ var webCmd = &cobra.Command{
 			}
 		}
 
-		c, err := config.Resolve()
+		c, err := config.Resolve(nil)
 		if err != nil {
 			slog.Warn("Config resolution had errors", "error", err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,19 +116,27 @@ func (c *Config) String() string {
 	return string(data)
 }
 
+// ResolveOptions overrides default paths for the project and local config layers.
+// Zero value means use the standard paths (.lazylogcat/config.json and
+// .lazylogcat/config.local.json). The global user config path is not overridden.
+type ResolveOptions struct {
+	ProjectConfigPath string
+	LocalConfigPath   string
+}
+
 // Resolve discovers and merges configuration from all layers in order:
 //  1. Default configuration
 //  2. Global user config: ~/.config/lazylogcat/config.json
-//  3. Project config: .lazylogcat/config.json
-//  4. Local override: .lazylogcat/config.local.json
+//  3. Project config: .lazylogcat/config.json (or ProjectConfigPath when set)
+//  4. Local override: .lazylogcat/config.local.json (or LocalConfigPath when set)
 //
-// Returns the merged config and any non-fatal errors encountered during loading.
-// Always returns a usable config, even if some files fail to load.
-func Resolve() (Config, error) {
+// opts may be nil. Returns the merged config and any non-fatal errors encountered
+// during loading. Always returns a usable config, even if some files fail to load.
+func Resolve(opts *ResolveOptions) (Config, error) {
 	cfg := DefaultConfig()
 	var errs []error
 
-	for _, path := range configPaths() {
+	for _, path := range configPaths(opts) {
 		overlay, err := loadFile(path)
 		if err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
@@ -145,7 +153,7 @@ func Resolve() (Config, error) {
 }
 
 // configPaths returns the ordered list of config file paths to check.
-func configPaths() []string {
+func configPaths(opts *ResolveOptions) []string {
 	var paths []string
 
 	// Layer 1: Global user config (~/.config/lazylogcat/config.json)
@@ -154,10 +162,18 @@ func configPaths() []string {
 	}
 
 	// Layer 2: Project config (.lazylogcat/config.json)
-	paths = append(paths, filepath.Join(".lazylogcat", "config.json"))
+	proj := filepath.Join(".lazylogcat", "config.json")
+	if opts != nil && opts.ProjectConfigPath != "" {
+		proj = opts.ProjectConfigPath
+	}
+	paths = append(paths, proj)
 
 	// Layer 3: Local override (.lazylogcat/config.local.json)
-	paths = append(paths, filepath.Join(".lazylogcat", "config.local.json"))
+	local := filepath.Join(".lazylogcat", "config.local.json")
+	if opts != nil && opts.LocalConfigPath != "" {
+		local = opts.LocalConfigPath
+	}
+	paths = append(paths, local)
 
 	return paths
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -718,9 +718,9 @@ func TestResolve(t *testing.T) {
 		}
 		defer os.Chdir(origDir)
 
-		got, err := Resolve()
+		got, err := Resolve(nil)
 		if err != nil {
-			t.Errorf("Resolve() error = %v, want nil", err)
+			t.Errorf("Resolve(nil) error = %v, want nil", err)
 		}
 
 		compareConfigs(t, got, DefaultConfig())
@@ -738,9 +738,9 @@ func TestResolve(t *testing.T) {
 			"filter": {"package_name": "com.project"}
 		}`)
 
-		got, err := Resolve()
+		got, err := Resolve(nil)
 		if err != nil {
-			t.Errorf("Resolve() error = %v, want nil", err)
+			t.Errorf("Resolve(nil) error = %v, want nil", err)
 		}
 
 		want := DefaultConfig()
@@ -765,9 +765,9 @@ func TestResolve(t *testing.T) {
 			"filter": {"package_name": "com.local"}
 		}`)
 
-		got, err := Resolve()
+		got, err := Resolve(nil)
 		if err != nil {
-			t.Errorf("Resolve() error = %v, want nil", err)
+			t.Errorf("Resolve(nil) error = %v, want nil", err)
 		}
 
 		want := DefaultConfig()
@@ -792,9 +792,9 @@ func TestResolve(t *testing.T) {
 			"filter": {"package_name": "com.local"}
 		}`)
 
-		got, err := Resolve()
+		got, err := Resolve(nil)
 		if err == nil {
-			t.Error("Resolve() error = nil, want error for invalid file")
+			t.Error("Resolve(nil) error = nil, want error for invalid file")
 		}
 
 		// Local config should still be applied over defaults
@@ -828,9 +828,9 @@ func TestResolve(t *testing.T) {
 			"filter": {"log_tag": "LocalTag"}
 		}`)
 
-		got, err := Resolve()
+		got, err := Resolve(nil)
 		if err != nil {
-			t.Errorf("Resolve() error = %v, want nil", err)
+			t.Errorf("Resolve(nil) error = %v, want nil", err)
 		}
 
 		want := DefaultConfig()
@@ -861,9 +861,9 @@ func TestResolve(t *testing.T) {
 			}
 		}`)
 
-		got, err := Resolve()
+		got, err := Resolve(nil)
 		if err != nil {
-			t.Errorf("Resolve() error = %v, want nil", err)
+			t.Errorf("Resolve(nil) error = %v, want nil", err)
 		}
 
 		want := DefaultConfig()
@@ -889,9 +889,9 @@ func TestResolve(t *testing.T) {
 			"display": {"wrap": false, "columns": {"date": false}}
 		}`)
 
-		got, err := Resolve()
+		got, err := Resolve(nil)
 		if err != nil {
-			t.Errorf("Resolve() error = %v, want nil", err)
+			t.Errorf("Resolve(nil) error = %v, want nil", err)
 		}
 
 		want := DefaultConfig()


### PR DESCRIPTION
## Summary

- `config.ResolveOptions`: override project / local config file paths; wired to persistent `--config` and `--config-local` on the root command (TUI, `config show`, `logs`).
- `lazylogcat version --json`: machine-readable version output.

## Stack

**4 / 4** — builds on #36; tip of the stack.
