### PR TITLE
fix(tui): visual mode selection fixes

### DIFF
--- a/internal/tui/logcatui/logcat_view.go
+++ b/internal/tui/logcatui/logcat_view.go
@@ -235,7 +235,7 @@ func (m LogcatViewModel) Update(msg tea.Msg) (LogcatViewModel, tea.Cmd) {
 		m.showCommandDialog = false
 		switch msg.Command {
 		case model.CommandReconnect:
-			m.visualMode = false
+			m.exitVisualMode()
 			return m, func() tea.Msg { return tui.ReconnectLogcatCmd{} }
 		case model.CommandExportBuffer:
 			return m, m.exportBuffer()
@@ -541,18 +541,30 @@ func (m *LogcatViewModel) handleGlobalKey(key string) (updateResult, bool) {
 		return updateResult{}, true
 
 	case "v":
-		m.visualMode = !m.visualMode
 		if m.visualMode {
-			m.viewport.GotoBottom()
-			m.currentLine = m.log.Size() - 1
+			m.exitVisualMode()
+			// Reader goroutine kept running during visual mode;
+			// next batchTickMsg will drain accumulated lines.
 			return updateResult{needsRender: true}, true
 		}
-		// Reader goroutine kept running during visual mode;
-		// next batchTickMsg will drain accumulated lines.
+		m.enterVisualMode()
 		return updateResult{needsRender: true}, true
 	}
 
 	return updateResult{}, false
+}
+
+func (m *LogcatViewModel) enterVisualMode() {
+	m.visualMode = true
+	m.startSelected = -1
+	m.viewport.GotoBottom()
+	m.currentLine = m.log.Size() - 1
+}
+
+func (m *LogcatViewModel) exitVisualMode() {
+	m.visualMode = false
+	m.currentLine = -1
+	m.startSelected = -1
 }
 
 // handleNormalModeKey handles keys specific to normal (non-visual) mode
@@ -599,7 +611,7 @@ func (m *LogcatViewModel) handleShortcutKey(key string) updateResult {
 	if cmdData.Type == model.CommandTypeAction {
 		switch cmdData.Command {
 		case model.CommandReconnect:
-			m.visualMode = false
+			m.exitVisualMode()
 			return updateResult{cmd: func() tea.Msg { return tui.ReconnectLogcatCmd{} }}
 		case model.CommandExit:
 			return updateResult{cmd: func() tea.Msg { return tui.ExitCmd{} }}
@@ -636,8 +648,7 @@ func (m *LogcatViewModel) handleVisualModeKey(key string) updateResult {
 		return updateResult{}
 
 	case "esc":
-		m.visualMode = false
-		m.startSelected = -1
+		m.exitVisualMode()
 		// Reader goroutine kept running during visual mode;
 		// next batchTickMsg will drain accumulated lines.
 		return updateResult{}

--- a/internal/tui/logcatui/logcat_view.go
+++ b/internal/tui/logcatui/logcat_view.go
@@ -2,6 +2,7 @@ package logcatui
 
 import (
 	"fmt"
+	"image/color"
 	"log/slog"
 	"os"
 	"strings"
@@ -67,6 +68,7 @@ type LogcatViewModel struct {
 	startSelected       int
 	visualLineToLogLine []int
 	logLineVisualStart  []int
+	logLineColor        []color.Color
 	awaitingShortcut    bool
 	connGen             uint64 // incremented on each voluntary reconnect; used to discard stale messages
 	toast               tui.ToastModel
@@ -479,8 +481,10 @@ func (m *LogcatViewModel) Render() {
 	cols := m.outputPrefs.Columns
 	m.visualLineToLogLine = m.visualLineToLogLine[:0]
 	m.logLineVisualStart = m.logLineVisualStart[:0]
+	m.logLineColor = m.logLineColor[:0]
 	for i, logLine := range logs {
 		m.logLineVisualStart = append(m.logLineVisualStart, len(m.visualLineToLogLine))
+		m.logLineColor = append(m.logLineColor, theme.GetLogColor(logLine.Level))
 		line := logLine.ModifiedString(cols)
 		var content string
 		if m.outputPrefs.SoftWrap {
@@ -489,12 +493,7 @@ func (m *LogcatViewModel) Render() {
 			content = line
 		}
 
-		levelColor := theme.GetLogColor(logLine.Level)
-		if m.outputPrefs.Color && !theme.IsDefaultForeground(levelColor) {
-			b.WriteString(lipgloss.NewStyle().Foreground(levelColor).Render(content))
-		} else {
-			b.WriteString(content)
-		}
+		b.WriteString(content)
 		b.WriteString("\n")
 		for range strings.Count(content, "\n") + 1 {
 			m.visualLineToLogLine = append(m.visualLineToLogLine, i)
@@ -752,17 +751,27 @@ func (m *LogcatViewModel) ensureLineVisible() {
 }
 
 func (m LogcatViewModel) visualLineStyle(lineIndex int) lipgloss.Style {
-	if !m.visualMode || lineIndex < 0 || lineIndex >= len(m.visualLineToLogLine) {
+	if lineIndex < 0 || lineIndex >= len(m.visualLineToLogLine) {
 		return lipgloss.NewStyle()
 	}
 	logLine := m.visualLineToLogLine[lineIndex]
-	if !m.logLineSelected(logLine) {
+	if m.visualMode && m.logLineSelected(logLine) {
+		return lipgloss.NewStyle().
+			Background(theme.ColorVisualBG).
+			Foreground(theme.ColorVisualFG).
+			Width(m.viewport.Width())
+	}
+	if !m.outputPrefs.Color {
 		return lipgloss.NewStyle()
 	}
-	return lipgloss.NewStyle().
-		Background(theme.ColorVisualBG).
-		Foreground(theme.ColorVisualFG).
-		Width(m.viewport.Width())
+	if logLine < 0 || logLine >= len(m.logLineColor) {
+		return lipgloss.NewStyle()
+	}
+	levelColor := m.logLineColor[logLine]
+	if theme.IsDefaultForeground(levelColor) {
+		return lipgloss.NewStyle()
+	}
+	return lipgloss.NewStyle().Foreground(levelColor)
 }
 
 func (m LogcatViewModel) logLineSelected(line int) bool {

--- a/internal/tui/logcatui/logcat_view_test.go
+++ b/internal/tui/logcatui/logcat_view_test.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/lipgloss/v2"
+
 	"github.com/parfenovvs/lazylogcat/internal/model"
+	"github.com/parfenovvs/lazylogcat/internal/tui/theme"
 )
 
 func testOutputPrefs() model.OutputPrefs {
@@ -79,6 +82,34 @@ func TestVisualSelectionStyleUsesWrappedLineMap(t *testing.T) {
 		if !strings.Contains(rendered, "\x1b[") {
 			t.Fatalf("visual line %d for selected log line was not styled", visualLine)
 		}
+	}
+}
+
+func TestVisualSelectionForegroundOverridesLogLevelColor(t *testing.T) {
+	prefs := testOutputPrefs()
+	prefs.Color = true
+	m := New(model.Size{Width: 42, Height: 8}, nil, "", model.Filter{}, prefs)
+	appendLogLines(&m, 1)
+	m.Render()
+
+	if strings.Contains(m.viewport.GetContent(), "\x1b[") {
+		t.Fatal("viewport content contains ANSI styling")
+	}
+	if got := m.viewportView(); !strings.Contains(got, "\x1b[") {
+		t.Fatal("viewport view did not apply log level styling")
+	}
+
+	m.visualMode = true
+	m.currentLine = 0
+
+	got := m.visualLineStyle(0).Render("selected")
+	want := lipgloss.NewStyle().
+		Background(theme.ColorVisualBG).
+		Foreground(theme.ColorVisualFG).
+		Width(m.viewport.Width()).
+		Render("selected")
+	if got != want {
+		t.Fatalf("selected visual style did not override log level style\n got: %q\nwant: %q", got, want)
 	}
 }
 

--- a/internal/tui/logcatui/logcat_view_test.go
+++ b/internal/tui/logcatui/logcat_view_test.go
@@ -113,6 +113,64 @@ func TestVisualSelectionForegroundOverridesLogLevelColor(t *testing.T) {
 	}
 }
 
+func TestExitingVisualModeResetsSelectionState(t *testing.T) {
+	m := New(model.Size{Width: 42, Height: 8}, nil, "", model.Filter{}, testOutputPrefs())
+	appendLogLines(&m, 10)
+	m.Render()
+
+	m.visualMode = true
+	m.currentLine = 3
+	m.startSelected = 1
+
+	m.handleVisualModeKey("esc")
+
+	if m.visualMode {
+		t.Fatal("visualMode = true, want false")
+	}
+	if m.currentLine != -1 {
+		t.Fatalf("currentLine = %d, want -1", m.currentLine)
+	}
+	if m.startSelected != -1 {
+		t.Fatalf("startSelected = %d, want -1", m.startSelected)
+	}
+}
+
+func TestVisualToggleReentersWithFreshSelectionState(t *testing.T) {
+	m := New(model.Size{Width: 42, Height: 8}, nil, "", model.Filter{}, testOutputPrefs())
+	appendLogLines(&m, 10)
+	m.Render()
+
+	m.visualMode = true
+	m.currentLine = 3
+	m.startSelected = 1
+
+	if _, handled := m.handleGlobalKey("v"); !handled {
+		t.Fatal("visual toggle was not handled")
+	}
+	if m.visualMode {
+		t.Fatal("visualMode = true after exit, want false")
+	}
+	if m.currentLine != -1 {
+		t.Fatalf("currentLine after exit = %d, want -1", m.currentLine)
+	}
+	if m.startSelected != -1 {
+		t.Fatalf("startSelected after exit = %d, want -1", m.startSelected)
+	}
+
+	if _, handled := m.handleGlobalKey("v"); !handled {
+		t.Fatal("visual toggle was not handled")
+	}
+	if !m.visualMode {
+		t.Fatal("visualMode = false after reentry, want true")
+	}
+	if m.currentLine != m.log.Size()-1 {
+		t.Fatalf("currentLine after reentry = %d, want %d", m.currentLine, m.log.Size()-1)
+	}
+	if m.startSelected != -1 {
+		t.Fatalf("startSelected after reentry = %d, want -1", m.startSelected)
+	}
+}
+
 func TestBuildShortcutMap(t *testing.T) {
 	m := buildShortcutMap()
 


### PR DESCRIPTION
## Summary

- Visual selection highlight now overrides log-level colors — previously a selected line could render with its level color instead of the visual highlight color
- Exiting visual mode now resets `currentLine` to `-1` in addition to clearing `startSelected` — stale cursor position no longer leaks back into normal mode

## Changes

**fix(tui): let visual selection override log colors** (`oyo`)
- Added `logLineColor []color.Color` slice precomputed in `Render()` alongside existing `logLineVisualStart`/`visualLineToLogLine`
- `visualLineStyle()`: selected lines return visual highlight style unconditionally; unselected lines fall back to cached level color via `logLineColor`
- Log level color rendering moved from content string (baked ANSI) to `StyleLineFunc` so colors stay out of the raw content buffer
- Test: `TestVisualSelectionForegroundOverridesLogLevelColor`

**fix(tui): reset visual selection on exit** (`znp`)
- Extracted `enterVisualMode()` and `exitVisualMode()` helpers; all exit paths (`esc`, `v` toggle, reconnect, command palette) now call `exitVisualMode()` which resets `visualMode`, `currentLine`, and `startSelected`
- Tests: `TestExitingVisualModeResetsSelectionState`, `TestVisualToggleReentersWithFreshSelectionState`