### PR TITLE
feat(tui): add ctrl+j/ctrl+k vim-style navigation in command palette

### DIFF
--- a/internal/tui/commandui/command_dialog.go
+++ b/internal/tui/commandui/command_dialog.go
@@ -302,7 +302,7 @@ func (m CommandDialogModel) updateCommands(msg tea.KeyPressMsg, key string) (Com
 	}
 
 	// Arrow keys go to table navigation
-	if key == "up" || key == "down" {
+	if key == "up" || key == "down" || key == "ctrl+j" || key == "ctrl+k" {
 		prevCursor := m.table.Cursor()
 		m.table, _ = m.table.Update(msg)
 		newCursor := m.table.Cursor()

--- a/internal/tui/commandui/multi_select.go
+++ b/internal/tui/commandui/multi_select.go
@@ -103,7 +103,7 @@ func (m MultiSelectModel) Update(msg tea.KeyPressMsg, key string) (MultiSelectMo
 	}
 
 	// Arrow keys go to table navigation
-	if key == "up" || key == "down" {
+	if key == "up" || key == "down" || key == "ctrl+k" || key == "ctrl+j" {
 		m.table, _ = m.table.Update(msg)
 		return m, nil
 	}

--- a/internal/tui/commandui/single_select.go
+++ b/internal/tui/commandui/single_select.go
@@ -95,7 +95,7 @@ func (m SingleSelectModel) Update(msg tea.KeyPressMsg, key string) (SingleSelect
 	}
 
 	// Arrow keys go to table navigation
-	if key == "up" || key == "down" {
+	if key == "up" || key == "down" || key == "ctrl+k" || key == "ctrl+j" {
 		if len(m.itemMap) > 0 {
 			m.table, _ = m.table.Update(msg)
 		}

--- a/internal/tui/commandui/table.go
+++ b/internal/tui/commandui/table.go
@@ -16,6 +16,8 @@ func newTable(columns []table.Column, rows []table.Row, height int) table.Model 
 	km.HalfPageUp.SetEnabled(false)
 	km.HalfPageDown.SetEnabled(false)
 	km.PageDown.SetEnabled(false)
+	km.LineUp.SetKeys("up", "ctrl+k")
+	km.LineDown.SetKeys("down", "ctrl+j")
 
 	s := table.Styles{
 		Header:   theme.TableHeader(),


### PR DESCRIPTION
## Summary

- Add `ctrl+j` / `ctrl+k` as Vim-style alternatives to arrow keys for navigating command palette lists
- Keeps parity with muscle memory for users who prefer Vim-style bindings in terminal UIs

## Changes

- `commandui/table.go`: register `ctrl+k`/`ctrl+j` in the bubbles table keymap (`LineUp`/`LineDown`) so the component handles them natively
- `commandui/command_dialog.go`, `multi_select.go`, `single_select.go`: extend key-routing condition to forward `ctrl+j`/`ctrl+k` to the table alongside arrow keys