### PR TITLE
fix(ui): header width calculation

### DIFF
--- a/internal/tui/logcatui/logcat_view.go
+++ b/internal/tui/logcatui/logcat_view.go
@@ -873,7 +873,7 @@ func (m LogcatViewModel) headerView() string {
 
 	// border (2) + padding (2) = 4 chars horizontal overhead
 	innerWidth := m.viewport.Width() - 4
-	style := titleStyle.Width(m.viewport.Width() - 2)
+	style := titleStyle.Width(m.viewport.Width())
 
 	// Toast has higher priority: reserve space for it first, then truncate header content
 	toastStr := m.toast.View()


### PR DESCRIPTION
## Summary

- Fix header width in logcat view — removes incorrect `-2` offset from `titleStyle.Width()`
- `lipgloss` Width sets content area; border/padding are added on top, so manual subtraction caused header to render 2 chars narrower than the viewport

## Changes

- `internal/tui/logcatui/logcat_view.go`: change `titleStyle.Width(m.viewport.Width() - 2)` to `titleStyle.Width(m.viewport.Width())`