### PR TITLE
fix(tui): stop forcing width on visually selected log lines

### DIFF
--- a/internal/tui/logcatui/logcat_view.go
+++ b/internal/tui/logcatui/logcat_view.go
@@ -769,8 +769,7 @@ func (m LogcatViewModel) visualLineStyle(lineIndex int) lipgloss.Style {
 	if m.visualMode && m.logLineSelected(logLine) {
 		return lipgloss.NewStyle().
 			Background(theme.ColorVisualBG).
-			Foreground(theme.ColorVisualFG).
-			Width(m.viewport.Width())
+			Foreground(theme.ColorVisualFG)
 	}
 	if !m.outputPrefs.Color {
 		return lipgloss.NewStyle()

--- a/internal/tui/logcatui/logcat_view_test.go
+++ b/internal/tui/logcatui/logcat_view_test.go
@@ -106,7 +106,6 @@ func TestVisualSelectionForegroundOverridesLogLevelColor(t *testing.T) {
 	want := lipgloss.NewStyle().
 		Background(theme.ColorVisualBG).
 		Foreground(theme.ColorVisualFG).
-		Width(m.viewport.Width()).
 		Render("selected")
 	if got != want {
 		t.Fatalf("selected visual style did not override log level style\n got: %q\nwant: %q", got, want)


### PR DESCRIPTION
## Summary

- Removes `.Width(m.viewport.Width())` from the visual selection style in the logcat view
- Forcing a fixed width caused selected lines to be padded or clipped to the viewport width, producing incorrect rendering (especially visible after the header width fix in the previous commit)

## Changes

- `internal/tui/logcatui/logcat_view.go`: drop `Width()` call from the visual selection lipgloss style