### PR TITLE
visual mode improvements and clipboard handling

### DIFF
--- a/internal/tui/logcatui/logcat_view.go
+++ b/internal/tui/logcatui/logcat_view.go
@@ -673,18 +673,19 @@ func (m *LogcatViewModel) handleVisualModeKey(key string) updateResult {
 				}
 				err = util.CopyToClipboard(lines...)
 				m.startSelected = -1
-				m.exitVisualMode()
-				return updateResult{}
 			} else {
 				logs := m.log.Recent(m.log.Size() - m.currentLine)
 				lineText := strings.TrimSpace(logs[0].ModifiedString(m.outputPrefs.Columns))
 				err = util.CopyToClipboard(lineText)
 			}
+			toastCmd := m.toast.Show("Copied to clipboard", tui.ToastInfo)
 			if err != nil {
 				slog.Error("Failed to copy to clipboard", "error", err)
+				toastCmd = m.toast.Show("Copy failed", tui.ToastError)
 			}
+			m.exitVisualMode()
+			return updateResult{cmd: toastCmd}
 		}
-		m.exitVisualMode()
 		return updateResult{}
 
 	case "ctrl+e":

--- a/internal/tui/logcatui/logcat_view.go
+++ b/internal/tui/logcatui/logcat_view.go
@@ -673,6 +673,7 @@ func (m *LogcatViewModel) handleVisualModeKey(key string) updateResult {
 				}
 				err = util.CopyToClipboard(lines...)
 				m.startSelected = -1
+				m.exitVisualMode()
 				return updateResult{}
 			} else {
 				logs := m.log.Recent(m.log.Size() - m.currentLine)
@@ -683,6 +684,7 @@ func (m *LogcatViewModel) handleVisualModeKey(key string) updateResult {
 				slog.Error("Failed to copy to clipboard", "error", err)
 			}
 		}
+		m.exitVisualMode()
 		return updateResult{}
 
 	case "ctrl+e":

--- a/internal/tui/logcatui/logcat_view.go
+++ b/internal/tui/logcatui/logcat_view.go
@@ -538,6 +538,9 @@ func (m *LogcatViewModel) handleGlobalKey(key string) (updateResult, bool) {
 	switch key {
 	case "G":
 		m.viewport.GotoBottom()
+		if m.visualMode {
+			m.currentLine = m.log.Size() - 1
+		}
 		return updateResult{}, true
 
 	case "v":

--- a/internal/tui/logcatui/logcat_view.go
+++ b/internal/tui/logcatui/logcat_view.go
@@ -557,8 +557,12 @@ func (m *LogcatViewModel) handleGlobalKey(key string) (updateResult, bool) {
 func (m *LogcatViewModel) enterVisualMode() {
 	m.visualMode = true
 	m.startSelected = -1
-	m.viewport.GotoBottom()
-	m.currentLine = m.log.Size() - 1
+	if m.viewport.AtBottom() {
+		m.currentLine = m.log.Size() - 1
+	} else {
+		centerVisual := m.viewport.YOffset() + (m.viewport.Height()-1)/2
+		m.currentLine = m.visualLineToLogLine[centerVisual]
+	}
 }
 
 func (m *LogcatViewModel) exitVisualMode() {

--- a/internal/tui/logcatui/logcat_view_test.go
+++ b/internal/tui/logcatui/logcat_view_test.go
@@ -134,7 +134,13 @@ func TestExitingVisualModeResetsSelectionState(t *testing.T) {
 	}
 }
 
-func TestVisualToggleReentersWithFreshSelectionState(t *testing.T) {
+// centerViewportLogLine matches enterVisualMode's anchor when the viewport is not at bottom.
+func centerViewportLogLine(m *LogcatViewModel) int {
+	center := m.viewport.YOffset() + (m.viewport.Height()-1)/2
+	return m.visualLineToLogLine[center]
+}
+
+func TestVisualToggleReentryFreshStateAnchorsCenterWhenNotAtBottom(t *testing.T) {
 	m := New(model.Size{Width: 42, Height: 8}, nil, "", model.Filter{}, testOutputPrefs())
 	appendLogLines(&m, 10)
 	m.Render()
@@ -155,6 +161,45 @@ func TestVisualToggleReentersWithFreshSelectionState(t *testing.T) {
 	if m.startSelected != -1 {
 		t.Fatalf("startSelected after exit = %d, want -1", m.startSelected)
 	}
+
+	if _, handled := m.handleGlobalKey("v"); !handled {
+		t.Fatal("visual toggle was not handled")
+	}
+	if !m.visualMode {
+		t.Fatal("visualMode = false after reentry, want true")
+	}
+	want := centerViewportLogLine(&m)
+	if m.currentLine != want {
+		t.Fatalf("currentLine after reentry = %d, want %d (center-row log line)", m.currentLine, want)
+	}
+	if m.startSelected != -1 {
+		t.Fatalf("startSelected after reentry = %d, want -1", m.startSelected)
+	}
+}
+
+func TestVisualToggleReentryFreshStateAnchorsLastLineWhenAtBottom(t *testing.T) {
+	m := New(model.Size{Width: 42, Height: 8}, nil, "", model.Filter{}, testOutputPrefs())
+	appendLogLines(&m, 10)
+	m.Render()
+
+	m.visualMode = true
+	m.currentLine = 3
+	m.startSelected = 1
+
+	if _, handled := m.handleGlobalKey("v"); !handled {
+		t.Fatal("visual toggle was not handled")
+	}
+	if m.visualMode {
+		t.Fatal("visualMode = true after exit, want false")
+	}
+	if m.currentLine != -1 {
+		t.Fatalf("currentLine after exit = %d, want -1", m.currentLine)
+	}
+	if m.startSelected != -1 {
+		t.Fatalf("startSelected after exit = %d, want -1", m.startSelected)
+	}
+
+	m.viewport.GotoBottom()
 
 	if _, handled := m.handleGlobalKey("v"); !handled {
 		t.Fatal("visual toggle was not handled")


### PR DESCRIPTION
## Summary

Polish visual mode behavior:
- Exit visual mode after clipboard copy (with toast notification)
- Sync cursor to last log entry on G (go to end)
- Center cursor in viewport on visual mode entry

## Changes

- Exit visual mode and show toast after clipboard copy
- Handle all clipboard copy cases consistently
- Proper cursor positioning on G command in visual mode
- Viewport centering when entering visual mode