### PR TITLE
feat(tui): reusable dialog frame and ctrl+x shortcut help

### DIFF
--- a/internal/model/shortcut.go
+++ b/internal/model/shortcut.go
@@ -1,0 +1,25 @@
+package model
+
+import "strings"
+
+type Shortcut struct {
+	Key  string
+	Name string
+}
+
+// CtrlXShortcuts lists ctrl+x second-key bindings from [Commands] for help overlays.
+func CtrlXShortcuts() []Shortcut {
+	var out []Shortcut
+	for _, group := range Commands() {
+		for _, cmd := range group.Commands {
+			if cmd.Shortcut == "" {
+				continue
+			}
+			parts := strings.SplitN(cmd.Shortcut, " ", 2)
+			if len(parts) == 2 && parts[0] == "ctrl+x" {
+				out = append(out, Shortcut{Key: parts[1], Name: cmd.Name})
+			}
+		}
+	}
+	return out
+}

--- a/internal/tui/commandui/command_dialog.go
+++ b/internal/tui/commandui/command_dialog.go
@@ -8,10 +8,10 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/charmbracelet/x/ansi"
 
 	"github.com/parfenovvs/lazylogcat/internal/model"
 	"github.com/parfenovvs/lazylogcat/internal/tui"
+	"github.com/parfenovvs/lazylogcat/internal/tui/commonui"
 	"github.com/parfenovvs/lazylogcat/internal/tui/theme"
 )
 
@@ -39,28 +39,6 @@ const (
 	stateTextInput
 	stateMultiSelect
 )
-
-var dialogStyle = func() lipgloss.Style {
-	return theme.Dialog().
-		Width(tui.DialogWidth).
-		MaxHeight(tui.DialogMaxHeight)
-}
-
-// dialogTitleWithESC renders a title line with "ESC" right-aligned.
-// Used by all dialog View() methods to show the dismiss hint in the title bar.
-func dialogTitleWithESC(title string) string {
-	titleStr := theme.DialogTitle().Render(title)
-	escStr := theme.DialogHelp().Render("ESC")
-	// innerWidth = DialogWidth - border(2) - padding(2)
-	innerWidth := tui.DialogWidth - 4
-	titleWidth := ansi.StringWidth(titleStr)
-	rightWidth := innerWidth - titleWidth
-	rightPart := lipgloss.NewStyle().
-		Width(rightWidth).
-		AlignHorizontal(lipgloss.Right).
-		Render(escStr)
-	return titleStr + rightPart
-}
 
 type CommandDialogModel struct {
 	state      dialogState
@@ -458,7 +436,7 @@ func (m CommandDialogModel) View() string {
 }
 
 func (m CommandDialogModel) viewCommands() string {
-	title := dialogTitleWithESC("Commands")
+	title := commonui.DialogTitleWithESC("Commands")
 	footer := theme.DialogHelp().Render("")
 
 	var body string
@@ -470,5 +448,5 @@ func (m CommandDialogModel) viewCommands() string {
 
 	search := theme.DialogSearch().Render(m.searchInput.View())
 	content := title + "\n\n" + search + "\n" + body + "\n\n" + footer
-	return dialogStyle().Render(content)
+	return commonui.DialogFrameStyle().Render(content)
 }

--- a/internal/tui/commandui/device_dialog.go
+++ b/internal/tui/commandui/device_dialog.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/parfenovvs/lazylogcat/internal/model"
 	"github.com/parfenovvs/lazylogcat/internal/tui"
+	"github.com/parfenovvs/lazylogcat/internal/tui/commonui"
 	"github.com/parfenovvs/lazylogcat/internal/tui/theme"
 	"github.com/parfenovvs/lazylogcat/internal/util"
 )
@@ -84,7 +85,7 @@ func (m CommandDialogModel) updateDevices(msg tea.KeyPressMsg, key string) (Comm
 
 func (m CommandDialogModel) viewDevices() string {
 	// Devices has special error/empty states, so we render manually instead of using singleSelect.View()
-	title := dialogTitleWithESC("Select Device")
+	title := commonui.DialogTitleWithESC("Select Device")
 
 	var body string
 	if m.deviceErr != nil {
@@ -102,5 +103,5 @@ func (m CommandDialogModel) viewDevices() string {
 
 	footer := theme.DialogHelp().Render("Refresh: r")
 	content := title + "\n\n" + body + "\n\n" + footer
-	return dialogStyle().Render(content)
+	return commonui.DialogFrameStyle().Render(content)
 }

--- a/internal/tui/commandui/multi_select.go
+++ b/internal/tui/commandui/multi_select.go
@@ -8,6 +8,7 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/parfenovvs/lazylogcat/internal/tui/commonui"
 	"github.com/parfenovvs/lazylogcat/internal/tui/theme"
 )
 
@@ -154,7 +155,7 @@ func (m *MultiSelectModel) filterRows() {
 
 // View renders the multi-select dialog.
 func (m MultiSelectModel) View() string {
-	title := dialogTitleWithESC(m.title)
+	title := commonui.DialogTitleWithESC(m.title)
 	footer := theme.DialogHelp().Render(m.footer)
 
 	var body string
@@ -166,5 +167,5 @@ func (m MultiSelectModel) View() string {
 
 	search := theme.DialogSearch().Render(m.searchInput.View())
 	content := title + "\n\n" + search + "\n" + body + "\n\n" + footer
-	return dialogStyle().Render(content)
+	return commonui.DialogFrameStyle().Render(content)
 }

--- a/internal/tui/commandui/single_select.go
+++ b/internal/tui/commandui/single_select.go
@@ -7,6 +7,7 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/parfenovvs/lazylogcat/internal/tui/commonui"
 	"github.com/parfenovvs/lazylogcat/internal/tui/theme"
 )
 
@@ -175,7 +176,7 @@ func (m *SingleSelectModel) Rebuild(items []SingleSelectItem, currentKey string)
 
 // View renders the single-select dialog.
 func (m SingleSelectModel) View() string {
-	title := dialogTitleWithESC(m.title)
+	title := commonui.DialogTitleWithESC(m.title)
 	footer := theme.DialogHelp().Render(m.footer)
 
 	var body string
@@ -187,5 +188,5 @@ func (m SingleSelectModel) View() string {
 
 	search := theme.DialogSearch().Render(m.searchInput.View())
 	content := title + "\n\n" + search + "\n" + body + "\n\n" + footer
-	return dialogStyle().Render(content)
+	return commonui.DialogFrameStyle().Render(content)
 }

--- a/internal/tui/commandui/text_input.go
+++ b/internal/tui/commandui/text_input.go
@@ -8,6 +8,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/parfenovvs/lazylogcat/internal/model"
+	"github.com/parfenovvs/lazylogcat/internal/tui/commonui"
 	"github.com/parfenovvs/lazylogcat/internal/tui/theme"
 )
 
@@ -112,7 +113,7 @@ func (m TextInputModel) Mode() model.TextFilterMode {
 
 // View renders the text input dialog.
 func (m TextInputModel) View() string {
-	title := dialogTitleWithESC(m.title)
+	title := commonui.DialogTitleWithESC(m.title)
 
 	var footer string
 	if m.modeEnabled {
@@ -128,7 +129,7 @@ func (m TextInputModel) View() string {
 
 	input := theme.DialogSearch().Render(m.input.View())
 	content := title + "\n\n" + input + errorLine + "\n\n" + footer
-	return dialogStyle().Render(content)
+	return commonui.DialogFrameStyle().Render(content)
 }
 
 // renderModeHint builds the "TAB contains | exact | regex" footer string

--- a/internal/tui/commonui/dialog.go
+++ b/internal/tui/commonui/dialog.go
@@ -1,0 +1,31 @@
+package commonui
+
+import (
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/parfenovvs/lazylogcat/internal/tui"
+	"github.com/parfenovvs/lazylogcat/internal/tui/theme"
+)
+
+// DialogTitleWithESC renders a title line with "ESC" right-aligned.
+// Used by all dialog View() methods to show the dismiss hint in the title bar.
+func DialogTitleWithESC(title string) string {
+	titleStr := theme.DialogTitle().Render(title)
+	escStr := theme.DialogHelp().Render("ESC")
+	// innerWidth = DialogWidth - border(2) - padding(2)
+	innerWidth := tui.DialogWidth - 4
+	titleWidth := ansi.StringWidth(titleStr)
+	rightWidth := innerWidth - titleWidth
+	rightPart := lipgloss.NewStyle().
+		Width(rightWidth).
+		AlignHorizontal(lipgloss.Right).
+		Render(escStr)
+	return titleStr + rightPart
+}
+
+// DialogFrameStyle returns the standard overlay dialog chrome (border, padding, default size).
+func DialogFrameStyle() lipgloss.Style {
+	return theme.Dialog().
+		Width(tui.DialogWidth).
+		MaxHeight(tui.DialogMaxHeight)
+}

--- a/internal/tui/helpui/shortcut_help_dialog.go
+++ b/internal/tui/helpui/shortcut_help_dialog.go
@@ -1,0 +1,45 @@
+package helpui
+
+import (
+	"slices"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/parfenovvs/lazylogcat/internal/model"
+	"github.com/parfenovvs/lazylogcat/internal/tui/commonui"
+	"github.com/parfenovvs/lazylogcat/internal/tui/theme"
+)
+
+// ShortcutHelpDialogModel shows ctrl+x shortcut hints while awaiting the second key.
+type ShortcutHelpDialogModel struct {
+	shortcuts []model.Shortcut
+}
+
+func NewShortcutHelpDialogModel(shortcuts []model.Shortcut) ShortcutHelpDialogModel {
+	cp := slices.Clone(shortcuts)
+	slices.SortFunc(cp, func(a, b model.Shortcut) int {
+		return strings.Compare(a.Key, b.Key)
+	})
+	return ShortcutHelpDialogModel{shortcuts: cp}
+}
+
+func (m ShortcutHelpDialogModel) View() string {
+	title := commonui.DialogTitleWithESC("")
+	var body string
+	if len(m.shortcuts) == 0 {
+		body = theme.DialogHelp().Render("\nNo shortcuts")
+	} else {
+		var b strings.Builder
+		for _, s := range m.shortcuts {
+			b.WriteString("  ")
+			b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(theme.ColorBrightMagenta).Render(s.Key))
+			b.WriteString("  →  ")
+			b.WriteString(s.Name)
+			b.WriteString("\n")
+		}
+		body = b.String()
+	}
+	content := title + "\n\n" + body
+	return commonui.DialogFrameStyle().Render(content)
+}

--- a/internal/tui/logcatui/logcat_view.go
+++ b/internal/tui/logcatui/logcat_view.go
@@ -16,6 +16,7 @@ import (
 	"github.com/parfenovvs/lazylogcat/internal/model"
 	"github.com/parfenovvs/lazylogcat/internal/tui"
 	"github.com/parfenovvs/lazylogcat/internal/tui/commandui"
+	"github.com/parfenovvs/lazylogcat/internal/tui/helpui"
 	"github.com/parfenovvs/lazylogcat/internal/tui/theme"
 	"github.com/parfenovvs/lazylogcat/internal/util"
 )
@@ -94,6 +95,7 @@ type LogcatViewModel struct {
 	toast               tui.ToastModel
 	showCommandDialog   bool
 	commandDialog       commandui.CommandDialogModel
+	shortcutDialog      helpui.ShortcutHelpDialogModel
 	deviceRequired      bool
 	recordingStartTime  *time.Time
 }
@@ -618,6 +620,7 @@ func (m *LogcatViewModel) handleNormalModeKey(key string) updateResult {
 
 	case "ctrl+x":
 		m.awaitingShortcut = true
+		m.shortcutDialog = helpui.NewShortcutHelpDialogModel(model.CtrlXShortcuts())
 		return updateResult{}
 	}
 
@@ -841,7 +844,9 @@ func (m LogcatViewModel) View() string {
 	baseView := m.renderBaseView()
 
 	if m.awaitingShortcut {
-		return tui.DimView(baseView)
+		dimmedBaseView := tui.DimView(baseView)
+		dialogContent := m.shortcutDialog.View()
+		return tui.OverlayDialog(m.parentSize, dimmedBaseView, dialogContent)
 	}
 
 	if m.showCommandDialog {

--- a/internal/tui/theme/theme.go
+++ b/internal/tui/theme/theme.go
@@ -67,6 +67,9 @@ var (
 
 	// ColorSelectedBG is the background for selected table rows.
 	ColorSelectedBG = lipgloss.Color(brightCyan)
+
+	// ColorBrightMagenta highlights shortcut keys in dialog help (ANSI bright magenta).
+	ColorBrightMagenta = lipgloss.Color(brightMagenta)
 )
 
 // GetLogColor returns a foreground color for the given logcat severity level.


### PR DESCRIPTION
## Summary

- Shared dialog chrome lives in `commonui.DialogFrameStyle()` next to `DialogTitleWithESC`, so palette/device/select/text dialogs reuse one frame without import cycles.
- `model.CtrlXShortcuts()` feeds a `helpui` overlay after `ctrl+x`: shortcuts sorted by key, bold bright-magenta keys, `→` before command names.
- `theme.ColorBrightMagenta` used for shortcut keys.

## Changes

- **commonui**: `dialog.go` — frame + title row helpers.
- **model**: `shortcut.go` — `Shortcut`, `CtrlXShortcuts()`.
- **commandui**: replace local frame style with `commonui.DialogFrameStyle()`.
- **helpui**: `ShortcutHelpDialogModel`.
- **logcatui**: open shortcut sheet when starting ctrl+x chord.
- **theme**: `ColorBrightMagenta`.

