### PR TITLE
fix: remove unnecessary empty line below footer

### DIFF
--- a/internal/tui/commandui/command_dialog.go
+++ b/internal/tui/commandui/command_dialog.go
@@ -437,7 +437,6 @@ func (m CommandDialogModel) View() string {
 
 func (m CommandDialogModel) viewCommands() string {
 	title := commonui.DialogTitleWithESC("Commands")
-	footer := theme.DialogHelp().Render("")
 
 	var body string
 	if len(m.table.Rows()) == 0 && m.searchInput.Value() != "" {
@@ -447,6 +446,6 @@ func (m CommandDialogModel) viewCommands() string {
 	}
 
 	search := theme.DialogSearch().Render(m.searchInput.View())
-	content := title + "\n\n" + search + "\n" + body + "\n\n" + footer
+	content := title + "\n\n" + search + "\n" + body
 	return commonui.DialogFrameStyle().Render(content)
 }

--- a/internal/tui/commandui/multi_select.go
+++ b/internal/tui/commandui/multi_select.go
@@ -156,7 +156,6 @@ func (m *MultiSelectModel) filterRows() {
 // View renders the multi-select dialog.
 func (m MultiSelectModel) View() string {
 	title := commonui.DialogTitleWithESC(m.title)
-	footer := theme.DialogHelp().Render(m.footer)
 
 	var body string
 	if len(m.table.Rows()) == 0 && m.searchInput.Value() != "" {
@@ -166,6 +165,9 @@ func (m MultiSelectModel) View() string {
 	}
 
 	search := theme.DialogSearch().Render(m.searchInput.View())
-	content := title + "\n\n" + search + "\n" + body + "\n\n" + footer
+	content := title + "\n\n" + search + "\n" + body
+	if m.footer != "" {
+		content += "\n\n" + theme.DialogHelp().Render(m.footer)
+	}
 	return commonui.DialogFrameStyle().Render(content)
 }

--- a/internal/tui/commandui/single_select.go
+++ b/internal/tui/commandui/single_select.go
@@ -177,7 +177,6 @@ func (m *SingleSelectModel) Rebuild(items []SingleSelectItem, currentKey string)
 // View renders the single-select dialog.
 func (m SingleSelectModel) View() string {
 	title := commonui.DialogTitleWithESC(m.title)
-	footer := theme.DialogHelp().Render(m.footer)
 
 	var body string
 	if len(m.table.Rows()) == 0 && m.searchInput.Value() != "" {
@@ -187,6 +186,9 @@ func (m SingleSelectModel) View() string {
 	}
 
 	search := theme.DialogSearch().Render(m.searchInput.View())
-	content := title + "\n\n" + search + "\n" + body + "\n\n" + footer
+	content := title + "\n\n" + search + "\n" + body
+	if m.footer != "" {
+		content += "\n\n" + theme.DialogHelp().Render(m.footer)
+	}
 	return commonui.DialogFrameStyle().Render(content)
 }

--- a/internal/tui/commandui/text_input.go
+++ b/internal/tui/commandui/text_input.go
@@ -115,20 +115,20 @@ func (m TextInputModel) Mode() model.TextFilterMode {
 func (m TextInputModel) View() string {
 	title := commonui.DialogTitleWithESC(m.title)
 
-	var footer string
-	if m.modeEnabled {
-		footer = theme.DialogHelp().Render(m.renderModeHint())
-	} else {
-		footer = theme.DialogHelp().Render(m.footer)
-	}
-
 	var errorLine string
 	if m.errorMsg != "" {
 		errorLine = "\n" + theme.DialogError().Render(m.errorMsg)
 	}
 
 	input := theme.DialogSearch().Render(m.input.View())
-	content := title + "\n\n" + input + errorLine + "\n\n" + footer
+	content := title + "\n\n" + input + errorLine
+
+	if m.modeEnabled {
+		content += "\n\n" + theme.DialogHelp().Render(m.renderModeHint())
+	} else if m.footer != "" {
+		content += "\n\n" + theme.DialogHelp().Render(m.footer)
+	}
+
 	return commonui.DialogFrameStyle().Render(content)
 }
 

--- a/internal/tui/logcatui/logcat_view.go
+++ b/internal/tui/logcatui/logcat_view.go
@@ -184,7 +184,7 @@ func New(parentSize model.Size, device *model.Device, deviceId string, filter mo
 	footerHeight := lipgloss.Height(m.footerView())
 	vp := viewport.New(
 		viewport.WithWidth(parentSize.Width),
-		viewport.WithHeight(parentSize.Height-footerHeight-headerHeight),
+		viewport.WithHeight(parentSize.Height-footerHeight-headerHeight-2),
 	)
 	m.viewport = vp
 
@@ -212,7 +212,7 @@ func (m LogcatViewModel) Update(msg tea.Msg) (LogcatViewModel, tea.Cmd) {
 		headerHeight := lipgloss.Height(m.headerView())
 		footerHeight := lipgloss.Height(m.footerView())
 		m.viewport.SetWidth(m.parentSize.Width)
-		m.viewport.SetHeight(m.parentSize.Height - footerHeight - headerHeight)
+		m.viewport.SetHeight(m.parentSize.Height - footerHeight - headerHeight - 2)
 		needsRender = true
 
 	case commandui.CommandDialogCloseMsg:
@@ -832,7 +832,12 @@ func (m LogcatViewModel) viewportView() string {
 }
 
 func (m LogcatViewModel) renderBaseView() string {
-	return m.headerView() + m.viewportView() + m.footerView()
+	return fmt.Sprintf(
+		"%s\n%s\n%s",
+		m.headerView(),
+		m.viewportView(),
+		m.footerView(),
+	)
 }
 
 func (m LogcatViewModel) View() string {

--- a/internal/tui/logcatui/logcat_view.go
+++ b/internal/tui/logcatui/logcat_view.go
@@ -184,7 +184,7 @@ func New(parentSize model.Size, device *model.Device, deviceId string, filter mo
 	footerHeight := lipgloss.Height(m.footerView())
 	vp := viewport.New(
 		viewport.WithWidth(parentSize.Width),
-		viewport.WithHeight(parentSize.Height-footerHeight-headerHeight),
+		viewport.WithHeight(parentSize.Height-footerHeight-headerHeight-2),
 	)
 	m.viewport = vp
 
@@ -212,7 +212,7 @@ func (m LogcatViewModel) Update(msg tea.Msg) (LogcatViewModel, tea.Cmd) {
 		headerHeight := lipgloss.Height(m.headerView())
 		footerHeight := lipgloss.Height(m.footerView())
 		m.viewport.SetWidth(m.parentSize.Width)
-		m.viewport.SetHeight(m.parentSize.Height - footerHeight - headerHeight - 1)
+		m.viewport.SetHeight(m.parentSize.Height - footerHeight - headerHeight - 2)
 		needsRender = true
 
 	case commandui.CommandDialogCloseMsg:

--- a/internal/tui/logcatui/logcat_view.go
+++ b/internal/tui/logcatui/logcat_view.go
@@ -184,7 +184,7 @@ func New(parentSize model.Size, device *model.Device, deviceId string, filter mo
 	footerHeight := lipgloss.Height(m.footerView())
 	vp := viewport.New(
 		viewport.WithWidth(parentSize.Width),
-		viewport.WithHeight(parentSize.Height-footerHeight-headerHeight-2),
+		viewport.WithHeight(parentSize.Height-footerHeight-headerHeight),
 	)
 	m.viewport = vp
 
@@ -212,7 +212,7 @@ func (m LogcatViewModel) Update(msg tea.Msg) (LogcatViewModel, tea.Cmd) {
 		headerHeight := lipgloss.Height(m.headerView())
 		footerHeight := lipgloss.Height(m.footerView())
 		m.viewport.SetWidth(m.parentSize.Width)
-		m.viewport.SetHeight(m.parentSize.Height - footerHeight - headerHeight - 2)
+		m.viewport.SetHeight(m.parentSize.Height - footerHeight - headerHeight)
 		needsRender = true
 
 	case commandui.CommandDialogCloseMsg:
@@ -832,12 +832,7 @@ func (m LogcatViewModel) viewportView() string {
 }
 
 func (m LogcatViewModel) renderBaseView() string {
-	return fmt.Sprintf(
-		"%s\n%s\n%s",
-		m.headerView(),
-		m.viewportView(),
-		m.footerView(),
-	)
+	return m.headerView() + m.viewportView() + m.footerView()
 }
 
 func (m LogcatViewModel) View() string {


### PR DESCRIPTION
Fixes #48

Dialogs were rendering an extra empty line when footer text was empty. This was visible in dialogs like the Log Level selector.

Changed View() methods to conditionally append the footer section only when footer text is non-empty.

Affected files:
- single_select.go
- multi_select.go  
- text_input.go
- command_dialog.go