### PR TITLE
feat: tag column width, number dialog, middle truncation

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -25,6 +25,12 @@
           "description": "Enable soft-wrapping of long log lines to fit the terminal width.",
           "default": true
         },
+        "tag_width": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 99,
+          "description": "Fixed width for the log tag column (terminal display width). Use 0 for automatic width."
+        },
         "columns": {
           "type": "object",
           "description": "Controls which fields of a parsed log line are visible.",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,9 +18,10 @@ type Config struct {
 
 // Display holds user preferences for log output appearance.
 type Display struct {
-	Color   *bool    `json:"color,omitempty"`
-	Wrap    *bool    `json:"wrap,omitempty"`
-	Columns *Columns `json:"columns,omitempty"`
+	Color    *bool    `json:"color,omitempty"`
+	Wrap     *bool    `json:"wrap,omitempty"`
+	TagWidth *int     `json:"tag_width,omitempty"`
+	Columns  *Columns `json:"columns,omitempty"`
 }
 
 // Columns controls which fields of a parsed log line are visible.
@@ -198,7 +199,7 @@ func loadFile(path string) (Config, error) {
 // Strings: non-empty overlay replaces base.
 // Slices: non-nil overlay replaces base entirely ([] explicitly clears).
 // TextFilter: non-zero overlay replaces base.
-// *bool: non-nil overlay replaces base.
+// *bool, *int: non-nil overlay replaces base.
 func merge(base, overlay Config) Config {
 	result := base
 
@@ -208,6 +209,9 @@ func merge(base, overlay Config) Config {
 	}
 	if overlay.Display.Wrap != nil {
 		result.Display.Wrap = overlay.Display.Wrap
+	}
+	if overlay.Display.TagWidth != nil {
+		result.Display.TagWidth = overlay.Display.TagWidth
 	}
 	if overlay.Display.Columns != nil {
 		if result.Display.Columns != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,6 +15,11 @@ func boolPtr(v bool) *bool {
 	return &v
 }
 
+// intPtr returns a pointer to an int value, useful for Config.Display.TagWidth.
+func intPtr(v int) *int {
+	return &v
+}
+
 // compareBoolPtr compares two *bool values and reports an error if they differ.
 func compareBoolPtr(t *testing.T, field string, got, want *bool) {
 	t.Helper()
@@ -49,6 +54,21 @@ func compareColumns(t *testing.T, got, want *Columns) {
 	compareBoolPtr(t, "Display.Columns.Message", got.Message, want.Message)
 }
 
+// compareIntPtr compares two *int values and reports an error if they differ.
+func compareIntPtr(t *testing.T, field string, got, want *int) {
+	t.Helper()
+	if got == nil && want == nil {
+		return
+	}
+	if got == nil || want == nil {
+		t.Errorf("%s = %v, want %v", field, got, want)
+		return
+	}
+	if *got != *want {
+		t.Errorf("%s = %v, want %v", field, *got, *want)
+	}
+}
+
 // compareConfigs compares two Config structs field by field and reports detailed errors.
 func compareConfigs(t *testing.T, got, want Config) {
 	t.Helper()
@@ -56,6 +76,7 @@ func compareConfigs(t *testing.T, got, want Config) {
 	// Compare Display
 	compareBoolPtr(t, "Display.Color", got.Display.Color, want.Display.Color)
 	compareBoolPtr(t, "Display.Wrap", got.Display.Wrap, want.Display.Wrap)
+	compareIntPtr(t, "Display.TagWidth", got.Display.TagWidth, want.Display.TagWidth)
 	compareColumns(t, got.Display.Columns, want.Display.Columns)
 
 	// Compare Filter
@@ -395,6 +416,11 @@ func TestLoadFile(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "TagWidth",
+			jsonData:   `{"display": {"tag_width": 17}}`,
+			wantConfig: Config{Display: Display{TagWidth: intPtr(17)}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -572,6 +598,28 @@ func TestMerge(t *testing.T) {
 				Display: Display{
 					Color: boolPtr(false),
 				},
+			},
+		},
+		{
+			name: "TagWidthOverlayReplacesBase",
+			base: Config{
+				Display: Display{TagWidth: intPtr(12)},
+			},
+			overlay: Config{
+				Display: Display{TagWidth: intPtr(24)},
+			},
+			want: Config{
+				Display: Display{TagWidth: intPtr(24)},
+			},
+		},
+		{
+			name: "NilTagWidthPreservesBase",
+			base: Config{
+				Display: Display{TagWidth: intPtr(12)},
+			},
+			overlay: Config{},
+			want: Config{
+				Display: Display{TagWidth: intPtr(12)},
 			},
 		},
 		{

--- a/internal/model/command.go
+++ b/internal/model/command.go
@@ -11,6 +11,7 @@ const (
 
 	// Style
 	CommandOutput
+	CommandTagWidth
 
 	// Connection
 	CommandReconnect
@@ -58,6 +59,7 @@ func Commands() []CommandGroup {
 			Name: "Style",
 			Commands: []CommandData{
 				{Command: CommandOutput, Type: CommandTypeNavigation, Name: "Output", Shortcut: "ctrl+x o"},
+				{Command: CommandTagWidth, Type: CommandTypeNavigation, Name: "Tag width"},
 			},
 		},
 		{

--- a/internal/model/logline.go
+++ b/internal/model/logline.go
@@ -3,6 +3,9 @@ package model
 import (
 	"fmt"
 	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/parfenovvs/lazylogcat/internal/strutil"
 )
 
 // LogLine represents a parsed logcat log line in the threadtime format.
@@ -107,9 +110,46 @@ func (l LogLine) String() string {
 	return l.Raw
 }
 
-// ModifiedString returns the log line with only the columns specified by cols.
+// truncateTagToWidth formats tag when ansi.StringWidth(tag) > width.
+// width 1: first rune only; width 2: first rune + ellipsis; wider: middle ellipsis via TruncateMiddle.
+func truncateTagToWidth(tag string, width int) string {
+	switch width {
+	case 1:
+		r := []rune(tag)
+		if len(r) == 0 {
+			return ""
+		}
+		return string(r[0])
+	case 2:
+		r := []rune(tag)
+		if len(r) == 0 {
+			return ""
+		}
+		return string(r[0]) + "…"
+	default:
+		return strutil.TruncateMiddle(tag, width)
+	}
+}
+
+// tagColumnToken returns the tag field as shown in ModifiedString (trim/pad + colon).
+func tagColumnToken(tag string, prefs OutputPrefs) string {
+	if prefs.TagWidth <= 0 {
+		return tag + ":"
+	}
+	w := prefs.TagWidth
+	if ansi.StringWidth(tag) <= w {
+		return strutil.PadANSIWidth(tag, w) + ":"
+	}
+	return truncateTagToWidth(tag, w) + ":"
+}
+
+// ModifiedString returns the log line with only the columns specified by prefs.Columns.
+// When prefs.Columns.Tag is enabled and prefs.TagWidth > 0, the tag is padded or truncated
+// to that width (narrow widths use first rune + optional ellipsis; wider uses middle ellipsis),
+// then ":" is appended.
 // If the line was not successfully parsed, the original raw line is returned.
-func (l LogLine) ModifiedString(cols Columns) string {
+func (l LogLine) ModifiedString(prefs OutputPrefs) string {
+	cols := prefs.Columns
 	if !l.Parsed() {
 		return l.Raw
 	}
@@ -130,7 +170,7 @@ func (l LogLine) ModifiedString(cols Columns) string {
 		parts = append(parts, l.Level)
 	}
 	if cols.Tag {
-		parts = append(parts, l.Tag+":")
+		parts = append(parts, tagColumnToken(l.Tag, prefs))
 	}
 	if cols.Message {
 		parts = append(parts, l.Message)
@@ -138,11 +178,13 @@ func (l LogLine) ModifiedString(cols Columns) string {
 	return strings.Join(parts, " ")
 }
 
-// PrefixWidth returns the visual width of all enabled columns before Message,
-// including the separating spaces. If Message is enabled the trailing space
-// between the last prefix column and the message is included.
+// PrefixWidth returns the UTF-8 byte offset into ModifiedString(prefs) where the
+// message text begins when Columns.Message is enabled (the offset follows the
+// single separator space between prefix columns and the message).
+// When Message is disabled, it returns len(ModifiedString(prefs)) (the full line length).
 // Returns 0 when the line was not parsed or no prefix columns are enabled.
-func (l LogLine) PrefixWidth(cols Columns) int {
+func (l LogLine) PrefixWidth(prefs OutputPrefs) int {
+	cols := prefs.Columns
 	if !l.Parsed() {
 		return 0
 	}
@@ -163,7 +205,7 @@ func (l LogLine) PrefixWidth(cols Columns) int {
 		parts = append(parts, l.Level)
 	}
 	if cols.Tag {
-		parts = append(parts, l.Tag+":")
+		parts = append(parts, tagColumnToken(l.Tag, prefs))
 	}
 	if len(parts) == 0 {
 		return 0

--- a/internal/model/logline_test.go
+++ b/internal/model/logline_test.go
@@ -340,7 +340,7 @@ func TestPrefixWidth(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.line.PrefixWidth(tt.cols)
+			got := tt.line.PrefixWidth(OutputPrefs{Columns: tt.cols})
 			if got != tt.want {
 				t.Errorf("PrefixWidth() = %d, want %d", got, tt.want)
 			}
@@ -366,8 +366,9 @@ func TestPrefixWidth_MatchesModifiedString(t *testing.T) {
 
 	for _, tc := range colSets {
 		t.Run(tc.name, func(t *testing.T) {
-			pw := line.PrefixWidth(tc.cols)
-			full := line.ModifiedString(tc.cols)
+			prefs := OutputPrefs{Columns: tc.cols}
+			pw := line.PrefixWidth(prefs)
+			full := line.ModifiedString(prefs)
 			if pw == 0 {
 				return // No prefix columns, nothing to check
 			}
@@ -381,5 +382,111 @@ func TestPrefixWidth_MatchesModifiedString(t *testing.T) {
 					msgPart, line.Message, full, pw)
 			}
 		})
+	}
+}
+
+func TestModifiedString_TagWidth(t *testing.T) {
+	line := ParseLogLine("02-08 12:12:09.629  3950  4005 D Short: hi")
+	longTag := ParseLogLine("02-08 12:12:09.629  3950  4005 D VeryLongTagHere: there")
+
+	tests := []struct {
+		name  string
+		line  LogLine
+		prefs OutputPrefs
+		want  string
+	}{
+		{
+			name: "AutoWidth_Unchanged",
+			line: line,
+			prefs: OutputPrefs{
+				Columns:  Columns{Tag: true, Message: true},
+				TagWidth: 0,
+			},
+			want: "Short: hi",
+		},
+		{
+			name: "PadShortTag",
+			line: line,
+			prefs: OutputPrefs{
+				Columns:  Columns{Tag: true, Message: true},
+				TagWidth: 10,
+			},
+			want: "Short     : hi",
+		},
+		{
+			name: "TruncateLongTag",
+			line: longTag,
+			prefs: OutputPrefs{
+				Columns:  Columns{Tag: true, Message: true},
+				TagWidth: 8,
+			},
+			want: "Ver…Here: there",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.line.ModifiedString(tt.prefs)
+			if got != tt.want {
+				t.Errorf("ModifiedString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModifiedString_TagWidth_Runes(t *testing.T) {
+	raw := "02-08 12:12:09.629  3950  4005 D 日本語: ok"
+	line := ParseLogLine(raw)
+	prefs := OutputPrefs{
+		Columns:  Columns{Tag: true, Message: true},
+		TagWidth: 2,
+	}
+	got := line.ModifiedString(prefs)
+	want := "日…: ok"
+	if got != want {
+		t.Errorf("ModifiedString() = %q, want %q", got, want)
+	}
+}
+
+func TestModifiedString_TagWidth_NarrowTruncate(t *testing.T) {
+	long := ParseLogLine("02-08 12:12:09.629  3950  4005 D Abcde: msg")
+	t.Run("Width1_firstRune", func(t *testing.T) {
+		got := long.ModifiedString(OutputPrefs{
+			Columns:  Columns{Tag: true, Message: true},
+			TagWidth: 1,
+		})
+		want := "A: msg"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+	t.Run("Width2_firstRuneAndEllipsis", func(t *testing.T) {
+		got := long.ModifiedString(OutputPrefs{
+			Columns:  Columns{Tag: true, Message: true},
+			TagWidth: 2,
+		})
+		want := "A…: msg"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}
+
+func TestPrefixWidth_MatchesModifiedString_TagWidth(t *testing.T) {
+	line := ParseLogLine("02-08 12:12:09.629  3950  4005 D BusinessScope: padded message text")
+	prefs := OutputPrefs{
+		Columns:  Columns{Tag: true, Message: true},
+		TagWidth: 6,
+	}
+	pw := line.PrefixWidth(prefs)
+	full := line.ModifiedString(prefs)
+	if pw > len(full) {
+		t.Fatalf("PrefixWidth(%d) > len(ModifiedString)(%d)", pw, len(full))
+	}
+	if got := full[pw:]; got != line.Message {
+		t.Errorf("full[PrefixWidth:] = %q, want %q (full=%q)", got, line.Message, full)
+	}
+	if want := "Bu…ope: padded message text"; full != want {
+		t.Errorf("ModifiedString() = %q, want %q", full, want)
 	}
 }

--- a/internal/model/output_prefs.go
+++ b/internal/model/output_prefs.go
@@ -16,4 +16,5 @@ type OutputPrefs struct {
 	Color    bool    `json:"color"`
 	SoftWrap bool    `json:"softWrap"`
 	Columns  Columns `json:"columns"`
+	TagWidth int     `json:"tagWidth"`
 }

--- a/internal/strutil/truncate_middle.go
+++ b/internal/strutil/truncate_middle.go
@@ -1,0 +1,40 @@
+package strutil
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// TruncateMiddle shortens s to about maxWidth terminal columns using an ellipsis in the middle.
+func TruncateMiddle(s string, maxWidth int) string {
+	w := ansi.StringWidth(s)
+	if w <= maxWidth {
+		return s
+	}
+	left := (maxWidth - 1) / 2
+	right := maxWidth - 1 - left
+
+	runes := []rune(s)
+	var suffix string
+	suffixW := 0
+	for i := len(runes) - 1; i >= 0 && suffixW < right; i-- {
+		suffixW++
+		suffix = string(runes[i]) + suffix
+	}
+
+	return ansi.Truncate(s, left, "") + "…" + suffix
+}
+
+// PadANSIWidth pads s with ASCII spaces so ansi.StringWidth(s) is at least targetWidth.
+// If s is already wider, it returns s unchanged.
+func PadANSIWidth(s string, targetWidth int) string {
+	if targetWidth <= 0 {
+		return s
+	}
+	sw := ansi.StringWidth(s)
+	if sw >= targetWidth {
+		return s
+	}
+	return s + strings.Repeat(" ", targetWidth-sw)
+}

--- a/internal/strutil/truncate_middle_test.go
+++ b/internal/strutil/truncate_middle_test.go
@@ -1,4 +1,4 @@
-package commandui
+package strutil
 
 import (
 	"strings"
@@ -21,18 +21,27 @@ func TestTruncateMiddle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := truncateMiddle(tt.input, tt.maxWidth)
+			got := TruncateMiddle(tt.input, tt.maxWidth)
 			if got != tt.want {
-				t.Errorf("truncateMiddle(%q, %d) = %q, want %q", tt.input, tt.maxWidth, got, tt.want)
+				t.Errorf("TruncateMiddle(%q, %d) = %q, want %q", tt.input, tt.maxWidth, got, tt.want)
 			}
 		})
 	}
 
 	t.Run("Unicode", func(t *testing.T) {
 		input := "日本語テスト文字列"
-		got := truncateMiddle(input, 5)
+		got := TruncateMiddle(input, 5)
 		if !strings.Contains(got, "…") {
-			t.Errorf("truncateMiddle(%q, 5) = %q, expected ellipsis in result", input, got)
+			t.Errorf("TruncateMiddle(%q, 5) = %q, expected ellipsis in result", input, got)
 		}
 	})
+}
+
+func TestPadANSIWidth(t *testing.T) {
+	if got := PadANSIWidth("hi", 5); got != "hi   " {
+		t.Errorf("PadANSIWidth(%q, 5) = %q", "hi", got)
+	}
+	if got := PadANSIWidth("hello", 3); got != "hello" {
+		t.Errorf("already wider string should be unchanged, got %q", got)
+	}
 }

--- a/internal/tui/commandui/command_dialog.go
+++ b/internal/tui/commandui/command_dialog.go
@@ -10,6 +10,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/parfenovvs/lazylogcat/internal/model"
+	"github.com/parfenovvs/lazylogcat/internal/strutil"
 	"github.com/parfenovvs/lazylogcat/internal/tui"
 	"github.com/parfenovvs/lazylogcat/internal/tui/commonui"
 	"github.com/parfenovvs/lazylogcat/internal/tui/theme"
@@ -38,6 +39,7 @@ const (
 	stateDevices
 	stateTextInput
 	stateMultiSelect
+	stateNumberInput
 )
 
 type CommandDialogModel struct {
@@ -55,6 +57,7 @@ type CommandDialogModel struct {
 	singleSelect SingleSelectModel
 	multiSelect  MultiSelectModel
 	textInputDlg TextInputModel
+	numberInput  NumberSelectorModel
 
 	// Context for the active subdialog
 	activeCommand model.Command
@@ -122,7 +125,7 @@ func NewDialog(cfg DialogConfig) CommandDialogModel {
 				continue
 			}
 			commandMap[len(rows)] = cmd
-			value := truncateMiddle(resolveValue(cmd.Command), 10)
+			value := strutil.TruncateMiddle(resolveValue(cmd.Command), 10)
 			rows = append(rows, table.Row{cmd.Name, value, cmd.Shortcut})
 		}
 	}
@@ -194,6 +197,10 @@ func (m CommandDialogModel) openSubdialog(cmd model.Command) (CommandDialogModel
 	case model.CommandOutput:
 		m.multiSelect = newOutputMultiSelect(m.outputPrefs)
 		m.state = stateMultiSelect
+	case model.CommandTagWidth:
+		m.numberInput = newTagWidthSelect(m.outputPrefs)
+		m.state = stateNumberInput
+		return m, initTextInputCmd()
 	case model.CommandDevices:
 		ss, allDevices, err := loadDevices(m.selectedDevice)
 		m.singleSelect = ss
@@ -224,6 +231,7 @@ func (m CommandDialogModel) Update(msg tea.Msg) (CommandDialogModel, tea.Cmd) {
 		if key == "ctrl+p" || key == "esc" {
 			if m.state == stateMultiSelect {
 				prefs := outputPrefsFromActive(m.multiSelect.ActiveItems())
+				prefs.TagWidth = m.outputPrefs.TagWidth
 				return m, func() tea.Msg { return OutputPrefsChangedMsg{OutputPrefs: prefs} }
 			}
 			return m, func() tea.Msg { return CommandDialogCloseMsg{} }
@@ -240,16 +248,16 @@ func (m CommandDialogModel) Update(msg tea.Msg) (CommandDialogModel, tea.Cmd) {
 			return m.updateTextInput(msg, key)
 		case stateMultiSelect:
 			return m.updateMultiSelect(msg, key)
+		case stateNumberInput:
+			return m.updateNumberInput(msg, key)
 		}
 	default:
-		// Forward non-key messages (e.g. cursor blink) to the active widget.
-		if m.state == stateTextInput {
+		// Forward non-key messages to the appropriate widget for cursor blink.
+		switch m.state {
+		case stateTextInput:
 			var cmd tea.Cmd
 			m.textInputDlg, cmd = m.textInputDlg.Update(msg)
 			return m, cmd
-		}
-		// Forward non-key messages to the appropriate widget for cursor blink.
-		switch m.state {
 		case stateLogLevel, stateDevices:
 			var cmd tea.Cmd
 			m.singleSelect, cmd = m.singleSelect.UpdateBlink(msg)
@@ -257,6 +265,10 @@ func (m CommandDialogModel) Update(msg tea.Msg) (CommandDialogModel, tea.Cmd) {
 		case stateMultiSelect:
 			var cmd tea.Cmd
 			m.multiSelect, cmd = m.multiSelect.UpdateBlink(msg)
+			return m, cmd
+		case stateNumberInput:
+			var cmd tea.Cmd
+			m.numberInput, cmd = m.numberInput.Update(msg)
 			return m, cmd
 		default:
 			var cmd tea.Cmd
@@ -430,6 +442,8 @@ func (m CommandDialogModel) View() string {
 		return m.textInputDlg.View()
 	case stateMultiSelect:
 		return m.multiSelect.View()
+	case stateNumberInput:
+		return m.numberInput.View()
 	default:
 		return m.viewCommands()
 	}

--- a/internal/tui/commandui/number_input.go
+++ b/internal/tui/commandui/number_input.go
@@ -1,0 +1,166 @@
+package commandui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"github.com/parfenovvs/lazylogcat/internal/tui/commonui"
+	"github.com/parfenovvs/lazylogcat/internal/tui/theme"
+)
+
+// defaultNumberInputCharLimit is used when NumberSelectorConfig.Max is unset (<= 0).
+const defaultNumberInputCharLimit = 12
+
+type NumberSelectorConfig struct {
+	Title  string
+	Footer string
+	Value  int
+	// Max optionally caps the allowed numeric range for sizing the input; when > 0,
+	// CharLimit is len(strconv.Itoa(Max)). When <= 0, defaultNumberInputCharLimit is used.
+	Max        int
+	ValidateFn func(value int) error
+}
+
+type NumberSelectorModel struct {
+	title      string
+	footer     string
+	input      textinput.Model
+	value      int
+	charLimit  int
+	validateFn func(value int) error
+	errorMsg   string
+	submitted  bool
+}
+
+func numberInputCharLimit(max int) int {
+	if max <= 0 {
+		return defaultNumberInputCharLimit
+	}
+	return len(strconv.Itoa(max))
+}
+
+func digitsOnly(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if unicode.IsDigit(r) {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func clampDigitLen(s string, maxLen int) string {
+	if maxLen <= 0 || len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen]
+}
+
+func newNumberSelect(cfg NumberSelectorConfig) NumberSelectorModel {
+	limit := numberInputCharLimit(cfg.Max)
+	ti := textinput.New()
+	ti.CharLimit = limit
+	ti.SetWidth(30)
+	initial := ""
+	if cfg.Value != 0 {
+		initial = clampDigitLen(digitsOnly(fmt.Sprint(cfg.Value)), limit)
+	}
+	ti.SetValue(initial)
+	ti.Focus()
+	return NumberSelectorModel{
+		title:      cfg.Title,
+		footer:     cfg.Footer,
+		input:      ti,
+		value:      cfg.Value,
+		charLimit:  limit,
+		validateFn: cfg.ValidateFn,
+		errorMsg:   "",
+	}
+}
+
+func (m NumberSelectorModel) applyDigitsOnlyToInput() NumberSelectorModel {
+	v := clampDigitLen(digitsOnly(m.input.Value()), m.charLimit)
+	if v != m.input.Value() {
+		m.input.SetValue(v)
+	}
+	return m
+}
+
+func (m NumberSelectorModel) Update(msg tea.Msg) (NumberSelectorModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		key := msg.String()
+		if key == "enter" {
+			value := strings.TrimSpace(digitsOnly(m.input.Value()))
+			if value == "" {
+				m.submitted = true
+				return m, nil
+			}
+			intValue, err := strconv.Atoi(value)
+			if err != nil {
+				m.errorMsg = "Please enter a valid number"
+				return m, nil
+			}
+			if m.validateFn != nil {
+				if err := m.validateFn(intValue); err != nil {
+					m.errorMsg = err.Error()
+					return m, nil
+				}
+			}
+			m.submitted = true
+			return m, nil
+		}
+
+		if len(key) == 1 {
+			r := rune(key[0])
+			if !unicode.IsDigit(r) && (unicode.IsPrint(r) || r == '\t') {
+				return m, nil
+			}
+		}
+
+		// Forward other keys to the text input, clear error on change
+		prevValue := m.input.Value()
+		var cmd tea.Cmd
+		m.input, cmd = m.input.Update(msg)
+		m = m.applyDigitsOnlyToInput()
+		if m.input.Value() != prevValue {
+			m.errorMsg = ""
+		}
+		return m, cmd
+
+	default:
+		// Forward non-key messages (e.g. cursor blink)
+		var cmd tea.Cmd
+		m.input, cmd = m.input.Update(msg)
+		m = m.applyDigitsOnlyToInput()
+		return m, cmd
+	}
+}
+
+// View renders the number selector dialog.
+func (m NumberSelectorModel) View() string {
+	title := commonui.DialogTitleWithESC(m.title)
+	footer := theme.DialogHelp().Render(m.footer)
+
+	var errorLine string
+	if m.errorMsg != "" {
+		errorLine = "\n" + theme.DialogError().Render(m.errorMsg)
+	}
+
+	input := theme.DialogSearch().Render(m.input.View())
+	content := title + "\n\n" + input + errorLine + "\n\n" + footer
+	return commonui.DialogFrameStyle().Render(content)
+}
+
+func (m NumberSelectorModel) Submitted() bool {
+	return m.submitted
+}
+
+func (m NumberSelectorModel) Value() int {
+	value, _ := strconv.Atoi(strings.TrimSpace(digitsOnly(m.input.Value())))
+	return value
+}

--- a/internal/tui/commandui/number_input_test.go
+++ b/internal/tui/commandui/number_input_test.go
@@ -1,0 +1,91 @@
+package commandui
+
+import (
+	"fmt"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestNumberInputCharLimit(t *testing.T) {
+	if got := numberInputCharLimit(99); got != 2 {
+		t.Errorf("numberInputCharLimit(99) = %d, want 2", got)
+	}
+	if got := numberInputCharLimit(9); got != 1 {
+		t.Errorf("numberInputCharLimit(9) = %d, want 1", got)
+	}
+	if got := numberInputCharLimit(0); got != defaultNumberInputCharLimit {
+		t.Errorf("numberInputCharLimit(0) = %d, want %d", got, defaultNumberInputCharLimit)
+	}
+}
+
+func TestDigitsOnly(t *testing.T) {
+	if got := digitsOnly("a1b2"); got != "12" {
+		t.Errorf("digitsOnly(...) = %q, want %q", got, "12")
+	}
+	if got := digitsOnly(""); got != "" {
+		t.Errorf("digitsOnly(\"\") = %q, want empty", got)
+	}
+}
+
+func TestNumberSelector_InitialZero_EmptyField(t *testing.T) {
+	m := newNumberSelect(NumberSelectorConfig{Value: 0, Max: 99})
+	if m.input.Value() != "" {
+		t.Errorf("initial Value 0 should show empty field, got %q", m.input.Value())
+	}
+}
+
+func TestNumberSelector_EnterEmpty_SubmitsZero(t *testing.T) {
+	m := newNumberSelect(NumberSelectorConfig{
+		Value: 99,
+		ValidateFn: func(value int) error {
+			if value < 0 {
+				return fmt.Errorf("negative")
+			}
+			return nil
+		},
+	})
+	m.input.SetValue("")
+	next, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	if !next.Submitted() {
+		t.Fatal("expected submitted")
+	}
+	if next.Value() != 0 {
+		t.Errorf("Value() = %d, want 0", next.Value())
+	}
+}
+
+func TestNumberSelector_StripsNonDigitsOnUpdate(t *testing.T) {
+	m := newNumberSelect(NumberSelectorConfig{Max: 0}) // default digit length cap
+	m.input.SetValue("12ab34")
+	next := m.applyDigitsOnlyToInput()
+	if next.input.Value() != "1234" {
+		t.Errorf("after sanitize value = %q, want %q", next.input.Value(), "1234")
+	}
+}
+
+func TestNumberSelector_MaxTruncatesInitialDigits(t *testing.T) {
+	m := newNumberSelect(NumberSelectorConfig{Max: 99, Value: 12345})
+	if got := m.input.Value(); got != "12" {
+		t.Errorf("initial input = %q, want %q", got, "12")
+	}
+	if m.charLimit != 2 {
+		t.Errorf("charLimit = %d, want 2", m.charLimit)
+	}
+}
+
+func TestNumberSelector_ValidateReject_NoSubmit(t *testing.T) {
+	m := newNumberSelect(NumberSelectorConfig{
+		ValidateFn: func(value int) error {
+			return fmt.Errorf("bad")
+		},
+	})
+	m.input.SetValue("3")
+	next, _ := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	if next.Submitted() {
+		t.Fatal("did not expect submitted")
+	}
+	if next.errorMsg == "" {
+		t.Fatal("expected error message")
+	}
+}

--- a/internal/tui/commandui/output_dialog.go
+++ b/internal/tui/commandui/output_dialog.go
@@ -85,3 +85,13 @@ func (m CommandDialogModel) updateMultiSelect(msg tea.KeyPressMsg, key string) (
 	m.multiSelect, _ = m.multiSelect.Update(msg, key)
 	return m, nil
 }
+
+func (m CommandDialogModel) updateNumberInput(msg tea.KeyPressMsg, key string) (CommandDialogModel, tea.Cmd) {
+	_ = key
+	m.numberInput, _ = m.numberInput.Update(msg)
+	if m.numberInput.Submitted() {
+		value := m.numberInput.Value()
+		return m, func() tea.Msg { return TagWidthSelectMsg{Width: value} }
+	}
+	return m, nil
+}

--- a/internal/tui/commandui/output_dialog_test.go
+++ b/internal/tui/commandui/output_dialog_test.go
@@ -68,3 +68,24 @@ func TestOutputPrefsFromActive(t *testing.T) {
 		})
 	}
 }
+
+func TestOutputPrefsMergePreservesTagWidth(t *testing.T) {
+	// Esc from Output multiselect merges columns from the widget but must keep TagWidth
+	// from the dialog model (see command_dialog Esc handling).
+	prev := model.OutputPrefs{
+		TagWidth: 17,
+		Color:    true,
+		Columns:  model.Columns{Time: true, Tag: true},
+	}
+	active := map[string]bool{"Wrap": true, "Level": true}
+	got := outputPrefsFromActive(active)
+	got.TagWidth = prev.TagWidth
+	want := model.OutputPrefs{
+		TagWidth: 17,
+		SoftWrap: true,
+		Columns:  model.Columns{Level: true},
+	}
+	if got != want {
+		t.Errorf("merged prefs = %+v, want %+v", got, want)
+	}
+}

--- a/internal/tui/commandui/table.go
+++ b/internal/tui/commandui/table.go
@@ -3,7 +3,6 @@ package commandui
 import (
 	"charm.land/bubbles/v2/table"
 	"charm.land/bubbles/v2/textinput"
-	"github.com/charmbracelet/x/ansi"
 
 	"github.com/parfenovvs/lazylogcat/internal/tui"
 	"github.com/parfenovvs/lazylogcat/internal/tui/theme"
@@ -38,25 +37,6 @@ func newTable(columns []table.Column, rows []table.Row, height int) table.Model 
 	t.SetStyles(s)
 
 	return t
-}
-
-func truncateMiddle(s string, maxWidth int) string {
-	w := ansi.StringWidth(s)
-	if w <= maxWidth {
-		return s
-	}
-	left := (maxWidth - 1) / 2
-	right := maxWidth - 1 - left
-
-	runes := []rune(s)
-	var suffix string
-	suffixW := 0
-	for i := len(runes) - 1; i >= 0 && suffixW < right; i-- {
-		suffixW++
-		suffix = string(runes[i]) + suffix
-	}
-
-	return ansi.Truncate(s, left, "") + "…" + suffix
 }
 
 func newSearchInput() textinput.Model {

--- a/internal/tui/commandui/tagwidth_dialog.go
+++ b/internal/tui/commandui/tagwidth_dialog.go
@@ -1,0 +1,30 @@
+package commandui
+
+import (
+	"fmt"
+
+	"github.com/parfenovvs/lazylogcat/internal/model"
+	"github.com/parfenovvs/lazylogcat/internal/util"
+)
+
+type TagWidthSelectMsg struct {
+	Width int
+}
+
+func newTagWidthSelect(prefs model.OutputPrefs) NumberSelectorModel {
+	return newNumberSelect(NumberSelectorConfig{
+		Title:  "Tag width",
+		Footer: "Set the width of the Tag column.\nEmpty or 0 for auto width.",
+		Value:  prefs.TagWidth,
+		Max:    util.MaxTagWidth,
+		ValidateFn: func(value int) error {
+			if value < 0 {
+				return fmt.Errorf("tag width cannot be negative")
+			}
+			if value > util.MaxTagWidth {
+				return fmt.Errorf("tag width cannot exceed %d", util.MaxTagWidth)
+			}
+			return nil
+		},
+	})
+}

--- a/internal/tui/logcatui/logcat_view.go
+++ b/internal/tui/logcatui/logcat_view.go
@@ -280,6 +280,12 @@ func (m LogcatViewModel) Update(msg tea.Msg) (LogcatViewModel, tea.Cmd) {
 		m.Render()
 		return m, nil
 
+	case commandui.TagWidthSelectMsg:
+		m.showCommandDialog = false
+		m.outputPrefs.TagWidth = msg.Width
+		m.Render()
+		return m, nil
+
 	case tui.ToastExpiredMsg:
 		m.toast.Update(msg)
 
@@ -396,12 +402,11 @@ func (m LogcatViewModel) Update(msg tea.Msg) (LogcatViewModel, tea.Cmd) {
 				if !wasAtBottom && m.log.Size() >= maxLogLines {
 					evictCount := min(len(lines), maxLogLines)
 					oldest := m.log.All()
-					cols := m.outputPrefs.Columns
 					for i := 0; i < evictCount && i < len(oldest); i++ {
 						if m.outputPrefs.SoftWrap {
 							rendered := softWrapIndent(
-								oldest[i].ModifiedString(cols),
-								oldest[i].PrefixWidth(cols),
+								oldest[i].ModifiedString(m.outputPrefs),
+								oldest[i].PrefixWidth(m.outputPrefs),
 								m.viewport.Width(),
 							)
 							yOffsetAdjust += lipgloss.Height(rendered)
@@ -456,24 +461,26 @@ func (m LogcatViewModel) Update(msg tea.Msg) (LogcatViewModel, tea.Cmd) {
 }
 
 // softWrapIndent wraps line so that the first terminal line occupies up to
-// viewportWidth characters and every continuation line is indented by
-// prefixWidth spaces (aligning with the start of the message column).
-// When prefixWidth is 0 or leaves no room for the message, it falls back to
-// a plain width-constrained render via lipgloss.
-func softWrapIndent(line string, prefixWidth, viewportWidth int) string {
-	msgWidth := viewportWidth - prefixWidth
-	if prefixWidth <= 0 || msgWidth < 4 {
+// viewportWidth cells and every continuation line is indented to align with the
+// start of the message column (prefixByteLen is a UTF-8 byte offset into line).
+// When indent cannot be derived or leaves too little room for the message, it
+// falls back to a plain width-constrained render via lipgloss.
+func softWrapIndent(line string, prefixByteLen, viewportWidth int) string {
+	prefix := ""
+	if prefixByteLen > 0 && prefixByteLen <= len(line) {
+		prefix = line[:prefixByteLen]
+	}
+	indentCols := ansi.StringWidth(prefix)
+	msgWidth := viewportWidth - indentCols
+	if indentCols <= 0 || msgWidth < 4 {
 		// Fallback: no useful indent possible
 		return lipgloss.NewStyle().Width(viewportWidth).Render(line)
 	}
 
 	// Split the assembled line into prefix and message portions.
-	// PrefixWidth includes the trailing space, so line[:prefixWidth] is the
-	// prefix with its separator and line[prefixWidth:] is the message text.
-	var prefix, message string
-	if prefixWidth < len(line) {
-		prefix = line[:prefixWidth]
-		message = line[prefixWidth:]
+	var message string
+	if prefixByteLen < len(line) {
+		message = line[prefixByteLen:]
 	} else {
 		// Line is shorter than or equal to the prefix (no message content)
 		return lipgloss.NewStyle().Width(viewportWidth).Render(line)
@@ -483,7 +490,7 @@ func softWrapIndent(line string, prefixWidth, viewportWidth int) string {
 	wrapped := ansi.Wrap(message, msgWidth, " ")
 	msgLines := strings.Split(wrapped, "\n")
 
-	indent := strings.Repeat(" ", prefixWidth)
+	indent := strings.Repeat(" ", indentCols)
 	var sb strings.Builder
 	for j, ml := range msgLines {
 		if j == 0 {
@@ -500,17 +507,16 @@ func softWrapIndent(line string, prefixWidth, viewportWidth int) string {
 func (m *LogcatViewModel) Render() {
 	var b strings.Builder
 	logs := m.log.All()
-	cols := m.outputPrefs.Columns
 	m.visualLineToLogLine = m.visualLineToLogLine[:0]
 	m.logLineVisualStart = m.logLineVisualStart[:0]
 	m.logLineColor = m.logLineColor[:0]
 	for i, logLine := range logs {
 		m.logLineVisualStart = append(m.logLineVisualStart, len(m.visualLineToLogLine))
 		m.logLineColor = append(m.logLineColor, theme.GetLogColor(logLine.Level))
-		line := logLine.ModifiedString(cols)
+		line := logLine.ModifiedString(m.outputPrefs)
 		var content string
 		if m.outputPrefs.SoftWrap {
-			content = softWrapIndent(line, logLine.PrefixWidth(cols), m.viewport.Width())
+			content = softWrapIndent(line, logLine.PrefixWidth(m.outputPrefs), m.viewport.Width())
 		} else {
 			content = line
 		}
@@ -692,13 +698,13 @@ func (m *LogcatViewModel) handleVisualModeKey(key string) updateResult {
 				var lines []string
 				logs := m.log.Recent(m.log.Size() - start)
 				for i := 0; i <= end-start; i++ {
-					lines = append(lines, strings.TrimSpace(logs[i].ModifiedString(m.outputPrefs.Columns)))
+					lines = append(lines, strings.TrimSpace(logs[i].ModifiedString(m.outputPrefs)))
 				}
 				err = util.CopyToClipboard(lines...)
 				m.startSelected = -1
 			} else {
 				logs := m.log.Recent(m.log.Size() - m.currentLine)
-				lineText := strings.TrimSpace(logs[0].ModifiedString(m.outputPrefs.Columns))
+				lineText := strings.TrimSpace(logs[0].ModifiedString(m.outputPrefs))
 				err = util.CopyToClipboard(lineText)
 			}
 			toastCmd := m.toast.Show("Copied to clipboard", tui.ToastInfo)
@@ -753,20 +759,19 @@ func (m *LogcatViewModel) selectedLines() []string {
 		return nil
 	}
 
-	cols := m.outputPrefs.Columns
 	if m.startSelected >= 0 {
 		start := min(m.currentLine, m.startSelected)
 		end := max(m.currentLine, m.startSelected)
 		logs := m.log.Recent(m.log.Size() - start)
 		lines := make([]string, 0, end-start+1)
 		for i := 0; i <= end-start; i++ {
-			lines = append(lines, strings.TrimSpace(logs[i].ModifiedString(cols)))
+			lines = append(lines, strings.TrimSpace(logs[i].ModifiedString(m.outputPrefs)))
 		}
 		return lines
 	}
 
 	logs := m.log.Recent(m.log.Size() - m.currentLine)
-	return []string{strings.TrimSpace(logs[0].ModifiedString(cols))}
+	return []string{strings.TrimSpace(logs[0].ModifiedString(m.outputPrefs))}
 }
 
 func (m *LogcatViewModel) ensureLineVisible() {
@@ -1001,7 +1006,7 @@ func (m *LogcatViewModel) exportBuffer() tea.Cmd {
 
 	var sb strings.Builder
 	for _, l := range lines {
-		sb.WriteString(strings.TrimSpace(l.ModifiedString(m.outputPrefs.Columns)))
+		sb.WriteString(strings.TrimSpace(l.ModifiedString(m.outputPrefs)))
 		sb.WriteByte('\n')
 	}
 
@@ -1040,7 +1045,7 @@ func (m *LogcatViewModel) stopRecording() tea.Cmd {
 
 	var sb strings.Builder
 	for _, l := range recorded {
-		sb.WriteString(strings.TrimSpace(l.ModifiedString(m.outputPrefs.Columns)))
+		sb.WriteString(strings.TrimSpace(l.ModifiedString(m.outputPrefs)))
 		sb.WriteByte('\n')
 	}
 

--- a/internal/tui/mainui/tui.go
+++ b/internal/tui/mainui/tui.go
@@ -61,6 +61,7 @@ func InitMainModel(c config.Config) MainModel {
 		Color:    util.ColorFromConfig(&c),
 		SoftWrap: util.WrapFromConfig(&c),
 		Columns:  util.ColumnsFromConfig(&c),
+		TagWidth: util.TagWidthFromConfig(&c),
 	}
 
 	// Always start in logcat view

--- a/internal/tui/util.go
+++ b/internal/tui/util.go
@@ -11,7 +11,7 @@ import (
 // Dialog size constants used by the command dialog overlay.
 const (
 	DialogWidth     = 48
-	DialogMaxHeight = 27
+	DialogMaxHeight = 28
 )
 
 // DimView applies a dimming effect to the view content

--- a/internal/util/mappers.go
+++ b/internal/util/mappers.go
@@ -5,6 +5,9 @@ import (
 	"github.com/parfenovvs/lazylogcat/internal/model"
 )
 
+// MaxTagWidth is the maximum fixed tag column width in terminal cells (matches config.schema.json).
+const MaxTagWidth = 99
+
 func FilterFromConfig(c *config.Config) model.Filter {
 	pkg := textFilterFromConfig(c.Filter.Pkg)
 	tag := textFilterFromConfig(c.Filter.Tag)
@@ -53,6 +56,22 @@ func WrapFromConfig(c *config.Config) bool {
 		return true
 	}
 	return *c.Display.Wrap
+}
+
+// TagWidthFromConfig returns model.OutputPrefs.TagWidth: 0 means auto width.
+// Values are clamped to [0, MaxTagWidth].
+func TagWidthFromConfig(c *config.Config) int {
+	if c.Display.TagWidth == nil {
+		return 0
+	}
+	w := *c.Display.TagWidth
+	if w < 0 {
+		return 0
+	}
+	if w > MaxTagWidth {
+		return MaxTagWidth
+	}
+	return w
 }
 
 func ColumnsFromConfig(c *config.Config) model.Columns {

--- a/internal/util/mappers_test.go
+++ b/internal/util/mappers_test.go
@@ -199,6 +199,31 @@ func TestWrapFromConfig(t *testing.T) {
 	}
 }
 
+func intPtr(v int) *int { return &v }
+
+func TestTagWidthFromConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config.Config
+		want int
+	}{
+		{name: "NilDefaultsZero", cfg: config.Config{}, want: 0},
+		{name: "ZeroExplicit", cfg: config.Config{Display: config.Display{TagWidth: intPtr(0)}}, want: 0},
+		{name: "InRange", cfg: config.Config{Display: config.Display{TagWidth: intPtr(42)}}, want: 42},
+		{name: "Max", cfg: config.Config{Display: config.Display{TagWidth: intPtr(MaxTagWidth)}}, want: MaxTagWidth},
+		{name: "NegativeClampedToZero", cfg: config.Config{Display: config.Display{TagWidth: intPtr(-1)}}, want: 0},
+		{name: "AboveMaxClamped", cfg: config.Config{Display: config.Display{TagWidth: intPtr(1000)}}, want: MaxTagWidth},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TagWidthFromConfig(&tt.cfg)
+			if got != tt.want {
+				t.Errorf("TagWidthFromConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestColumnsFromConfig(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

- Add configurable **log tag column width** (`display.tag_width` in config, 0 = auto) with TUI command flow and numeric input.
- **Middle truncation** helper for long tag/text display; wiring through log line rendering and mappers.
- Tests for config merge, truncation, number input, and output dialog.

## Changes

- `config.schema.json` + `internal/config`: `tag_width` display option and merge behavior.
- `internal/model`: `OutputPrefs.TagWidth`, command wiring, `LogLine` layout updates.
- `internal/strutil/truncate_middle.go`: shared truncation + tests (replacing prior table-only test placement).
- `internal/tui/commandui`: `tagwidth_dialog`, `number_input`, command/output dialog hooks; table simplification.
- `internal/tui/logcatui`, `internal/tui/mainui`, `internal/tui/util`, `internal/util/mappers`: render path updates.


